### PR TITLE
Extended the plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+node_modules
+*.vsix

--- a/language-configuration-slsql.json
+++ b/language-configuration-slsql.json
@@ -8,7 +8,6 @@
     ["[", "]"],
     ["(", ")"]
   ],
-  // symbols that are auto closed when typing
   "autoClosingPairs": [
     ["{", "}"],
     ["[", "]"],
@@ -16,20 +15,11 @@
     ["\"", "\""],
     ["'", "'"]
   ],
-  // symbols that can be used to surround a selection
   "surroundingPairs": [
     ["{", "}"],
     ["[", "]"],
     ["(", ")"],
     ["\"", "\""],
     ["'", "'"]
-  ],
-  "onEnterRules": [
-    {
-      "beforeText": "^\\s*(:FOR|:WHILE|:PROCEDURE|:IF|:BEGINCASE|:CASE|:TRY|:CATCH|:FINALLY|:REGION).*$",
-      "action": {
-        "indent": "indent"
-      }
-    }
   ]
 }

--- a/language-configuration-ssl.json
+++ b/language-configuration-ssl.json
@@ -1,0 +1,33 @@
+{
+  "comments": {
+    "blockComment": ["/*", "*/"],
+    "lineComment": "/*"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  "onEnterRules": [
+    {
+      "beforeText": "^\\s*(:FOR|:WHILE|:PROCEDURE|:IF|:BEGINCASE|:CASE|:TRY|:CATCH|:FINALLY|:REGION).*$",
+      "action": {
+        "indent": "indent"
+      }
+    }
+  ]
+}

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,10 +1,8 @@
 {
   "comments": {
-    // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-    "blockComment": ["/*", ";"],
+    "blockComment": ["/*", "*/|;"],
     "lineComment": "/*"
   },
-  // symbols used as brackets
   "brackets": [
     ["{", "}"],
     ["[", "]"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,592 @@
 {
     "name": "ssl-lang",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ssl-lang",
-            "version": "0.0.7",
+            "version": "0.0.8",
+            "devDependencies": {
+                "esbuild": "^0.17.19"
+            },
             "engines": {
                 "vscode": "^1.63.0"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+            "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+            "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+            "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+            "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+            "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+            "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+            "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+            "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+            "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+            "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+            "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+            "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+            "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+            "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+            "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+            "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+            "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+            "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+            "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+            "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+            "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+            "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+            "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/android-arm": "0.17.19",
+                "@esbuild/android-arm64": "0.17.19",
+                "@esbuild/android-x64": "0.17.19",
+                "@esbuild/darwin-arm64": "0.17.19",
+                "@esbuild/darwin-x64": "0.17.19",
+                "@esbuild/freebsd-arm64": "0.17.19",
+                "@esbuild/freebsd-x64": "0.17.19",
+                "@esbuild/linux-arm": "0.17.19",
+                "@esbuild/linux-arm64": "0.17.19",
+                "@esbuild/linux-ia32": "0.17.19",
+                "@esbuild/linux-loong64": "0.17.19",
+                "@esbuild/linux-mips64el": "0.17.19",
+                "@esbuild/linux-ppc64": "0.17.19",
+                "@esbuild/linux-riscv64": "0.17.19",
+                "@esbuild/linux-s390x": "0.17.19",
+                "@esbuild/linux-x64": "0.17.19",
+                "@esbuild/netbsd-x64": "0.17.19",
+                "@esbuild/openbsd-x64": "0.17.19",
+                "@esbuild/sunos-x64": "0.17.19",
+                "@esbuild/win32-arm64": "0.17.19",
+                "@esbuild/win32-ia32": "0.17.19",
+                "@esbuild/win32-x64": "0.17.19"
+            }
+        }
+    },
+    "dependencies": {
+        "@esbuild/android-arm": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+            "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+            "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+            "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/darwin-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+            "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/darwin-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+            "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/freebsd-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+            "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/freebsd-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+            "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-arm": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+            "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+            "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-ia32": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+            "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-loong64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+            "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-mips64el": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+            "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-ppc64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+            "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-riscv64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+            "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-s390x": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+            "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+            "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/netbsd-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+            "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/openbsd-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+            "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/sunos-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+            "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+            "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-ia32": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+            "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+            "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+            "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+            "dev": true,
+            "requires": {
+                "@esbuild/android-arm": "0.17.19",
+                "@esbuild/android-arm64": "0.17.19",
+                "@esbuild/android-x64": "0.17.19",
+                "@esbuild/darwin-arm64": "0.17.19",
+                "@esbuild/darwin-x64": "0.17.19",
+                "@esbuild/freebsd-arm64": "0.17.19",
+                "@esbuild/freebsd-x64": "0.17.19",
+                "@esbuild/linux-arm": "0.17.19",
+                "@esbuild/linux-arm64": "0.17.19",
+                "@esbuild/linux-ia32": "0.17.19",
+                "@esbuild/linux-loong64": "0.17.19",
+                "@esbuild/linux-mips64el": "0.17.19",
+                "@esbuild/linux-ppc64": "0.17.19",
+                "@esbuild/linux-riscv64": "0.17.19",
+                "@esbuild/linux-s390x": "0.17.19",
+                "@esbuild/linux-x64": "0.17.19",
+                "@esbuild/netbsd-x64": "0.17.19",
+                "@esbuild/openbsd-x64": "0.17.19",
+                "@esbuild/sunos-x64": "0.17.19",
+                "@esbuild/win32-arm64": "0.17.19",
+                "@esbuild/win32-ia32": "0.17.19",
+                "@esbuild/win32-x64": "0.17.19"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,16 @@
                     ".ssl",".srvscr"
                 ],
                 "configuration": "./language-configuration.json"
+            },
+            {
+                "id": "SQL",
+                "aliases": [
+                    "sql"
+                ],
+                "extensions": [
+                    ".slsql"
+                ],
+                "configuration": "./language-configuration.json"
             }
         ],
         "grammars": [
@@ -29,6 +39,11 @@
                 "language": "SSL",
                 "scopeName": "source.ssl",
                 "path": "./syntaxes/ssl.tmLanguage.json"
+            },
+            {
+                "language": "SQL",
+                "scopeName": "source.sql",
+                "path": "./syntaxes/sql.tmLanguage.json"
             }
         ],
         "snippets": [

--- a/package.json
+++ b/package.json
@@ -1,14 +1,19 @@
 {
     "name": "ssl-lang",
     "displayName": "SSL-lang",
-    "description": "SSL Language (unofficial)",
+    "description": "Starlims Scripting Language (SSL) theme and syntax highlighting for Visual Studio Code.",
     "publisher": "Janosch",
-    "version": "0.0.8",
+    "version": "0.0.10",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/jbouecke/ssl-lang"
+    },
     "engines": {
         "vscode": "^1.63.0"
     },
     "categories": [
-        "Programming Languages"
+        "Programming Languages",
+        "Themes"
     ],
     "contributes": {
         "languages": [
@@ -19,19 +24,20 @@
                     "ssl"
                 ],
                 "extensions": [
-                    ".ssl",".srvscr"
+                    ".ssl",
+                    ".srvscr"
                 ],
-                "configuration": "./language-configuration.json"
+                "configuration": "./language-configuration-ssl.json"
             },
             {
-                "id": "SQL",
+                "id": "SLSQL",
                 "aliases": [
-                    "sql"
+                    "slsql"
                 ],
                 "extensions": [
                     ".slsql"
                 ],
-                "configuration": "./language-configuration.json"
+                "configuration": "./language-configuration-slsql.json"
             }
         ],
         "grammars": [
@@ -41,9 +47,9 @@
                 "path": "./syntaxes/ssl.tmLanguage.json"
             },
             {
-                "language": "SQL",
-                "scopeName": "source.sql",
-                "path": "./syntaxes/sql.tmLanguage.json"
+                "language": "SLSQL",
+                "scopeName": "source.slsql",
+                "path": "./syntaxes/slsql.tmLanguage.json"
             }
         ],
         "snippets": [
@@ -51,6 +57,16 @@
                 "language": "SSL",
                 "path": "./snippets/snippets.json"
             }
+        ],
+        "themes": [
+            {
+                "label": "SSL Language Theme (Dark)",
+                "uiTheme": "vs-dark",
+                "path": "./themes/SSL Theme-color-theme.json"
+            }
         ]
+    },
+    "devDependencies": {
+        "esbuild": "^0.17.19"
     }
 }

--- a/syntaxes/slsql.tmLanguage copy.json
+++ b/syntaxes/slsql.tmLanguage copy.json
@@ -1,7 +1,7 @@
 {
 	"version": "https://github.com/microsoft/vscode-mssql/commit/3929516cce0a570e91ee1be74b09ed886cb360f4",
-	"name": "SQL",
-	"scopeName": "source.sql",
+	"name": "SLSQL",
+	"scopeName": "source.slsql",
 	"patterns": [
         {
             "include": "#keywordsStorage"
@@ -133,7 +133,7 @@
 			"name": "constant.numeric.sql"
 		},
 		{
-			"match": "(?i:\\b(select(\\s+(all|distinct))?|insert\\s+(ignore\\s+)?into|update|delete|from|set|where|group\\s+by|or|like|and|union(\\s+all)?|having|order\\s+by|limit|cross\\s+join|join|straight_join|(inner|(left|right|full)(\\s+outer)?)\\s+join|natural(\\s+(inner|(left|right|full)(\\s+outer)?))?\\s+join)\\b)",
+			"match": "(?i:\\b(select(\\s+(all|distinct))?|insert\\s+(ignore\\s+)?into|update|delete|from|on|as|set|where|group\\s+by|or|like|and|union(\\s+all)?|having|order\\s+by|limit|cross\\s+join|join|straight_join|(inner|(left|right|full)(\\s+outer)?)\\s+join|natural(\\s+(inner|(left|right|full)(\\s+outer)?))?\\s+join)\\b)",
 			"name": "keyword.other.DML.sql"
 		},
 		{

--- a/syntaxes/slsql.tmLanguage.json
+++ b/syntaxes/slsql.tmLanguage.json
@@ -1,0 +1,247 @@
+{
+	"version": "0.0.1",
+	"name": "SLSQL",
+	"scopeName": "source.slsql",
+	"patterns": [
+		{
+			"include": "#keywordsStorage"
+		},
+		{
+			"name": "string.quoted.double",
+			"begin": "\"",
+			"end": "\""
+		},
+		{
+			"name": "string.quoted.sinlge",
+			"begin": "'",
+			"end": "'"
+		},
+		{
+			"match": "((?<!@)@)\\b(\\w+)\\b",
+			"name": "variable.parameter.sql"
+		},
+		{
+			"match": "(\\[)[^\\]]*(\\])",
+			"name": "text.bracketed"
+		},
+		{
+			"include": "#comments"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "keyword.other.create.sql"
+				},
+				"2": {
+					"name": "keyword.other.sql"
+				},
+				"5": {
+					"name": "entity.name.function.sql"
+				}
+			},
+			"match": "(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+)(['\"`]?)(\\w+)\\4",
+			"name": "meta.create.sql"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "keyword.other.create.sql"
+				},
+				"2": {
+					"name": "keyword.other.sql"
+				}
+			},
+			"match": "(?i:^\\s*(drop)\\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view))",
+			"name": "meta.drop.sql"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "keyword.other.create.sql"
+				},
+				"2": {
+					"name": "keyword.other.table.sql"
+				},
+				"3": {
+					"name": "entity.name.function.sql"
+				},
+				"4": {
+					"name": "keyword.other.cascade.sql"
+				}
+			},
+			"match": "(?i:\\s*(drop)\\s+(table)\\s+(\\w+)(\\s+cascade)?\\b)",
+			"name": "meta.drop.sql"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "keyword.other.create.sql"
+				},
+				"2": {
+					"name": "keyword.other.table.sql"
+				}
+			},
+			"match": "(?i:^\\s*(alter)\\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|proc(edure)?|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+)",
+			"name": "meta.alter.sql"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "storage.type.sql"
+				},
+				"2": {
+					"name": "storage.type.sql"
+				},
+				"3": {
+					"name": "constant.numeric.sql"
+				},
+				"4": {
+					"name": "storage.type.sql"
+				},
+				"5": {
+					"name": "constant.numeric.sql"
+				},
+				"6": {
+					"name": "storage.type.sql"
+				},
+				"7": {
+					"name": "constant.numeric.sql"
+				},
+				"8": {
+					"name": "constant.numeric.sql"
+				},
+				"9": {
+					"name": "storage.type.sql"
+				},
+				"10": {
+					"name": "constant.numeric.sql"
+				},
+				"11": {
+					"name": "storage.type.sql"
+				},
+				"12": {
+					"name": "storage.type.sql"
+				},
+				"13": {
+					"name": "storage.type.sql"
+				},
+				"14": {
+					"name": "constant.numeric.sql"
+				},
+				"15": {
+					"name": "storage.type.sql"
+				}
+			},
+			"match": "(?xi)\\b(bigint|bigserial|bit|boolean|box|bytea|cidr|circle|date|double\\sprecision|inet|int|integer|line|lseg|macaddr|money|oid|path|point|polygon|real|serial|smallint|sysdate|text)\\b\n\n\t\t\t\t# numeric suffix, capture 2 + 3i\n\t\t\t\t|\\b(bit\\svarying|character\\s(?:varying)?|tinyint|var\\schar|float|interval)\\((\\d+)\\)\n\n\t\t\t\t# optional numeric suffix, capture 4 + 5i\n\t\t\t\t|\\b(char|number|varchar\\d?)\\b(?:\\((\\d+)\\))?\n\n\t\t\t\t# special case, capture 6 + 7i + 8i\n\t\t\t\t|\\b(numeric|decimal)\\b(?:\\((\\d+),(\\d+)\\))?\n\n\t\t\t\t# special case, captures 9, 10i, 11\n\t\t\t\t|\\b(times?)\\b(?:\\((\\d+)\\))?(\\swith(?:out)?\\stime\\szone\\b)?\n\n\t\t\t\t# special case, captures 12, 13, 14i, 15\n\t\t\t\t|\\b(timestamp)(?:(s|tz))?\\b(?:\\((\\d+)\\))?(\\s(with|without)\\stime\\szone\\b)?\n\n\t\t\t"
+		},
+		{
+			"match": "(?i:\\b((?:primary|foreign)\\s+key|references|on\\sdelete(\\s+cascade)?|nocheck|check|constraint|collate|default)\\b)",
+			"name": "storage.modifier.sql"
+		},
+		{
+			"match": "\\b\\d+\\b",
+			"name": "constant.numeric.sql"
+		},
+		{
+			"match": "(?i:\\b(select(\\s+(all|distinct))?|insert\\s+(ignore\\s+)?into|update|from|cross\\s+join|join|straight_join|(inner|(left|right|full)(\\s+outer)?)\\s+join|natural(\\s+(inner|(left|right|full)(\\s+outer)?))?\\s+join)\\s+(\\w+)\\s+\\b)(\\w+)",
+			"name": "keyword.table.sql",
+			"comment": "table name",
+			"captures": {
+				"1": {
+					"name": "keyword.other.DML.sql"
+				},
+				"2": {
+					"name": "keyword.table.sql"
+				},
+				"3": {
+					"name": "keyword.table.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i:\\b(on|off|((is\\s+)?not\\s+)?null)\\b)",
+			"name": "keyword.other.DDL.create.II.sql"
+		},
+		{
+			"match": "(?i)\\bAS\\b",
+			"name": "keyword.other.sql",
+			"captures": {
+				"1": {
+					"name": "keyword.other.alias.sql"
+				}
+			}
+		},
+		{
+			"match": "\\*",
+			"name": "keyword.operator.star.sql"
+		},
+		{
+			"match": "[!<>]?=|<>|<|>",
+			"name": "comparison.operator.sql"
+		},
+		{
+			"match": "-|\\+|/",
+			"name": "keyword.operator.math.sql"
+		},
+		{
+			"match": "\\|\\|",
+			"name": "keyword.operator.concatenator.sql"
+		},
+		{
+			"match": "(?i)\\b(abs|acos|asin|atan|atn2|ceiling|cos|cot|degrees|exp|floor|log|log10|pi|power|radians|rand|round|sign|sin|sqrt|square|tan)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.mathematical.sql"
+				}
+			}
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "constant.other.database-name.sql"
+				},
+				"2": {
+					"name": "constant.other.field-name.sql"
+				}
+			},
+			"match": "(\\w+?)\\.(\\w+)"
+		},
+		{
+			"include": "#strings"
+		},
+		{
+			"include": "#regexps"
+		},
+		{
+			"match": "(?i)\\b(ADD|ALL|ALTER|AND|ANY|AS|ASC|AUTHORIZATION|BACKUP|BEGIN|BETWEEN|BREAK|BROWSE|BULK|BY|CASCADE|CASE|CHECK|CHECKPOINT|CLOSE|CLUSTERED|COALESCE|COLLATE|COLUMN|COMMIT|COMPUTE|CONSTRAINT|CONTAINS|CONTAINSTABLE|CONTINUE|CONVERT|CREATE|CROSS|CURRENT|CURRENT_DATE|CURRENT_TIME|CURRENT_TIMESTAMP|CURRENT_USER|CURSOR|DATABASE|DBCC|DEALLOCATE|DECLARE|DEFAULT|DELETE|DENY|DESC|DISK|DISTINCT|DISTRIBUTED|DOUBLE|DROP|DUMP|ELSE|END|ERRLVL|ESCAPE|EXCEPT|EXEC|EXECUTE|EXISTS|EXIT|EXTERNAL|FETCH|FILE|FILLFACTOR|FOR|FOREIGN|FREETEXT|FREETEXTTABLE|FULL|FUNCTION|GOTO|GRANT|GROUP|HAVING|HOLDLOCK|IDENTITY|IDENTITY_INSERT|IDENTITYCOL|IF|IN|INDEX|INNER|INSERT|INTERSECT|INTO|IS|KEY|KILL|LIKE|LINENO|LOAD|MERGE|NATIONAL|NOCHECK|NONCLUSTERED|NOT|NULLIF|OF|OFF|OFFSETS|ON|OPEN|OPENDATASOURCE|OPENQUERY|OPENROWSET|OPENXML|OPTION|OR|ORDER|OUTER|OVER|PERCENT|PIVOT|PLAN|PRECISION|PRIMARY|PRINT|PROC|PROCEDURE|PUBLIC|RAISERROR|READ|READTEXT|RECONFIGURE|REFERENCES|REPLICATION|RESTORE|RESTRICT|RETURN|REVERT|REVOKE|RIGHT|ROLLBACK|ROWCOUNT|ROWGUIDCOL|RULE|SAVE|SCHEMA|SECURITYAUDIT|SEMANTICKEYPHRASETABLE|SEMANTICSIMILARITYDETAILSTABLE|SEMANTICSIMILARITYTABLE|SESSION_USER|SET|SETUSER|SHUTDOWN|SOME|STATISTICS|SYSTEM_USER|TABLE|TABLESAMPLE|TEXTSIZE|THEN|TO|TOP|TRAN|TRANSACTION|TRIGGER|TRUNCATE|TRY_CONVERT|TSEQUAL|UNION|UNIQUE|UNPIVOT|UPDATETEXT|USE|USER|VALUES|VARYING|VIEW|WAITFOR|WHEN|WHERE|WHILE|WITH|WRITETEXT)\\b",
+			"name": "keyword.other.sql"
+		},
+		{
+			"name": "keyword.function.sql",
+			"match": "(?i)\\b(ABS|ACOS|APP_NAME|APPLOCK_MODE|APPLOCK_TEST|ASCII|ASIN|ATAN|ATN2|AVG|BINARY_CHECKSUM|CAST|CEILING|CHAR|CHARINDEX|CHECKSUM|CHECKSUM_AGG|COL_LENGTH|COL_NAME|COLUMNPROPERTY|COMPUTE|CONCAT|CONCAT_WS|CONTAINSTABLE|CONTEXT_INFO|COS|COT|COUNT|COUNT_BIG|DATALENGTH|DATEADD|DATEDIFF|DATENAME|DATEPART|DATESERIAL|DATEFROMPARTS|DATETIME2FROMPARTS|DATETIMEFROMPARTS|DATETIMEOFFSETFROMPARTS|DAY|DB_ID|DB_NAME|DECRYPTBYASYMKEY|DECRYPTBYCERT|DECRYPTBYKEY|DECRYPTBYKEYAUTOASYMKEY|DECRYPTBYKEYAUTOCERT|DECRYPTBYKEYAUTOKEY|DECRYPTBYKEYAUTOSYMKEY|DECRYPTBYPASSPHRASE|DECRYPTBYTAN|DECRYPTBYTANASYMKEY|DECRYPTBYTANCERT|DECRYPTBYTANKEY|DECRYPTBYTANSYMKEY|DECRYPTBYTESTKEY|DECRYPTBYTESTKEYASYMKEY|DECRYPTBYTESTKEYCERT|DECRYPTBYTESTKEYKEY|DECRYPTBYTESTKEYSYMKEY|DEGREES|DIFFERENCE|ENCRYPTBYASYMKEY|ENCRYPTBYCERT|ENCRYPTBYKEY|ENCRYPTBYPASSPHRASE|ENCRYPTBYTAN|ENCRYPTBYTANASYMKEY|ENCRYPTBYTANCERT|ENCRYPTBYTANKEY|ENCRYPTBYTANSYMKEY|ENCRYPTBYTESTKEY|ENCRYPTBYTESTKEYASYMKEY|ENCRYPTBYTESTKEYCERT|ENCRYPTBYTESTKEYKEY|ENCRYPTBYTESTKEYSYMKEY|EXP|EXP_|FILE_ID|FILE_IDEX|FILE_NAME|FILEGROUP_ID|FILEGROUP_NAME|FILEGROUPPROPERTY|FILEPROPERTY|FLOOR|FORMAT|FULLTEXTCATALOGPROPERTY|FULLTEXTSERVICEPROPERTY|GETANSINULL|GET_FILESTREAM_TRANSACTION_CONTEXT|GETACTIVITYID|GETANSINULL|GETDATE|GETUTCDATE|HOST_ID|HOST_NAME|IDENT_CURRENT|IDENT_INCR|IDENT_SEED|INDEXKEY_PROPERTY|INDEXPROPERTY|IS_MEMBER|IS_SRVROLEMEMBER|ISDATE|ISNULL|ISNUMERIC|LEFT|LEN|LOG|LOG10|LOWER|LTRIM|MAX)\\w*\\("
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "punctuation.section.scope.begin.sql"
+				},
+				"2": {
+					"name": "punctuation.section.scope.end.sql"
+				}
+			},
+			"comment": "Allow for special ↩ behavior",
+			"match": "(\\()(\\))",
+			"name": "meta.block.sql"
+		}
+	],
+	"repository": {
+		"keywordsStorage": {
+			"patterns": [
+				{
+					"name": "keyword.control",
+					"match": ":(PUBLIC|DECLARE|CLASS|INHERIT|INCLUDE|PARAMETERS|PROCEDURE|ENDPROC|REGION|ENDREGION|BEGININLINECODE|ENDINLINECODE|ERROR)\\b"
+				}
+			]
+		}
+	}
+}

--- a/syntaxes/slsql.tmLanguage.json
+++ b/syntaxes/slsql.tmLanguage.json
@@ -242,6 +242,51 @@
 					"match": ":(PUBLIC|DECLARE|CLASS|INHERIT|INCLUDE|PARAMETERS|PROCEDURE|ENDPROC|REGION|ENDREGION|BEGININLINECODE|ENDINLINECODE|ERROR)\\b"
 				}
 			]
+		},
+		"comments": {
+			"patterns": [
+				{
+					"begin": "(^[ \\t]+)?(?=--)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.whitespace.comment.leading.sql"
+						}
+					},
+					"end": "(?!\\G)",
+					"patterns": [
+						{
+							"begin": "--",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.comment.sql"
+								}
+							},
+							"end": "\\n",
+							"name": "comment.line.double-dash.sql"
+						}
+					]
+				},
+				{
+					"begin": "(^[ \\t]+)?(?=#)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.whitespace.comment.leading.sql"
+						}
+					},
+					"end": "(?!\\G)",
+					"patterns": []
+				},
+				{
+					"begin": "/\\*",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.sql"
+						}
+					},
+					"end": "\\*/",
+					"name": "comment.block.c"
+				}
+			]
 		}
 	}
 }

--- a/syntaxes/sql.tmLanguage.json
+++ b/syntaxes/sql.tmLanguage.json
@@ -1,0 +1,633 @@
+{
+	"version": "https://github.com/microsoft/vscode-mssql/commit/3929516cce0a570e91ee1be74b09ed886cb360f4",
+	"name": "SQL",
+	"scopeName": "source.sql",
+	"patterns": [
+        {
+            "include": "#keywordsStorage"
+        },
+		{
+			"match": "((?<!@)@)\\b(\\w+)\\b",
+			"name": "variable.parameter.sql"
+		},
+		{
+			"match": "(\\[)[^\\]]*(\\])",
+			"name": "text.bracketed"
+		},
+		{
+			"include": "#comments"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "keyword.other.create.sql"
+				},
+				"2": {
+					"name": "keyword.other.sql"
+				},
+				"5": {
+					"name": "entity.name.function.sql"
+				}
+			},
+			"match": "(?i:^\\s*(create(?:\\s+or\\s+replace)?)\\s+(aggregate|conversion|database|domain|function|group|(unique\\s+)?index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+)(['\"`]?)(\\w+)\\4",
+			"name": "meta.create.sql"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "keyword.other.create.sql"
+				},
+				"2": {
+					"name": "keyword.other.sql"
+				}
+			},
+			"match": "(?i:^\\s*(drop)\\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|rule|schema|sequence|table|tablespace|trigger|type|user|view))",
+			"name": "meta.drop.sql"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "keyword.other.create.sql"
+				},
+				"2": {
+					"name": "keyword.other.table.sql"
+				},
+				"3": {
+					"name": "entity.name.function.sql"
+				},
+				"4": {
+					"name": "keyword.other.cascade.sql"
+				}
+			},
+			"match": "(?i:\\s*(drop)\\s+(table)\\s+(\\w+)(\\s+cascade)?\\b)",
+			"name": "meta.drop.sql"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "keyword.other.create.sql"
+				},
+				"2": {
+					"name": "keyword.other.table.sql"
+				}
+			},
+			"match": "(?i:^\\s*(alter)\\s+(aggregate|conversion|database|domain|function|group|index|language|operator class|operator|proc(edure)?|rule|schema|sequence|table|tablespace|trigger|type|user|view)\\s+)",
+			"name": "meta.alter.sql"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "storage.type.sql"
+				},
+				"2": {
+					"name": "storage.type.sql"
+				},
+				"3": {
+					"name": "constant.numeric.sql"
+				},
+				"4": {
+					"name": "storage.type.sql"
+				},
+				"5": {
+					"name": "constant.numeric.sql"
+				},
+				"6": {
+					"name": "storage.type.sql"
+				},
+				"7": {
+					"name": "constant.numeric.sql"
+				},
+				"8": {
+					"name": "constant.numeric.sql"
+				},
+				"9": {
+					"name": "storage.type.sql"
+				},
+				"10": {
+					"name": "constant.numeric.sql"
+				},
+				"11": {
+					"name": "storage.type.sql"
+				},
+				"12": {
+					"name": "storage.type.sql"
+				},
+				"13": {
+					"name": "storage.type.sql"
+				},
+				"14": {
+					"name": "constant.numeric.sql"
+				},
+				"15": {
+					"name": "storage.type.sql"
+				}
+			},
+			"match": "(?xi)\n\n\t\t\t\t# normal stuff, capture 1\n\t\t\t\t \\b(bigint|bigserial|bit|boolean|box|bytea|cidr|circle|date|double\\sprecision|inet|int|integer|line|lseg|macaddr|money|oid|path|point|polygon|real|serial|smallint|sysdate|text)\\b\n\n\t\t\t\t# numeric suffix, capture 2 + 3i\n\t\t\t\t|\\b(bit\\svarying|character\\s(?:varying)?|tinyint|var\\schar|float|interval)\\((\\d+)\\)\n\n\t\t\t\t# optional numeric suffix, capture 4 + 5i\n\t\t\t\t|\\b(char|number|varchar\\d?)\\b(?:\\((\\d+)\\))?\n\n\t\t\t\t# special case, capture 6 + 7i + 8i\n\t\t\t\t|\\b(numeric|decimal)\\b(?:\\((\\d+),(\\d+)\\))?\n\n\t\t\t\t# special case, captures 9, 10i, 11\n\t\t\t\t|\\b(times?)\\b(?:\\((\\d+)\\))?(\\swith(?:out)?\\stime\\szone\\b)?\n\n\t\t\t\t# special case, captures 12, 13, 14i, 15\n\t\t\t\t|\\b(timestamp)(?:(s|tz))?\\b(?:\\((\\d+)\\))?(\\s(with|without)\\stime\\szone\\b)?\n\n\t\t\t"
+		},
+		{
+			"match": "(?i:\\b((?:primary|foreign)\\s+key|references|on\\sdelete(\\s+cascade)?|nocheck|check|constraint|collate|default)\\b)",
+			"name": "storage.modifier.sql"
+		},
+		{
+			"match": "\\b\\d+\\b",
+			"name": "constant.numeric.sql"
+		},
+		{
+			"match": "(?i:\\b(select(\\s+(all|distinct))?|insert\\s+(ignore\\s+)?into|update|delete|from|set|where|group\\s+by|or|like|and|union(\\s+all)?|having|order\\s+by|limit|cross\\s+join|join|straight_join|(inner|(left|right|full)(\\s+outer)?)\\s+join|natural(\\s+(inner|(left|right|full)(\\s+outer)?))?\\s+join)\\b)",
+			"name": "keyword.other.DML.sql"
+		},
+		{
+			"match": "(?i:\\b(on|off|((is\\s+)?not\\s+)?null)\\b)",
+			"name": "keyword.other.DDL.create.II.sql"
+		},
+		{
+			"match": "(?i:\\bvalues\\b)",
+			"name": "keyword.other.DML.II.sql"
+		},
+		{
+			"match": "(?i:\\b(begin(\\s+work)?|start\\s+transaction|commit(\\s+work)?|rollback(\\s+work)?)\\b)",
+			"name": "keyword.other.LUW.sql"
+		},
+		{
+			"match": "(?i:\\b(grant(\\swith\\sgrant\\soption)?|revoke)\\b)",
+			"name": "keyword.other.authorization.sql"
+		},
+		{
+			"match": "(?i:\\bin\\b)",
+			"name": "keyword.other.data-integrity.sql"
+		},
+		{
+			"match": "(?i:^\\s*(comment\\s+on\\s+(table|column|aggregate|constraint|database|domain|function|index|operator|rule|schema|sequence|trigger|type|view))\\s+.*?\\s+(is)\\s+)",
+			"name": "keyword.other.object-comments.sql"
+		},
+		{
+			"match": "(?i)\\bAS\\b",
+			"name": "keyword.other.alias.sql"
+		},
+		{
+			"match": "(?i)\\b(DESC|ASC)\\b",
+			"name": "keyword.other.order.sql"
+		},
+		{
+			"match": "\\*",
+			"name": "keyword.operator.star.sql"
+		},
+		{
+			"match": "[!<>]?=|<>|<|>",
+			"name": "comparison.operator.sql"
+		},
+		{
+			"match": "-|\\+|/",
+			"name": "keyword.operator.math.sql"
+		},
+		{
+			"match": "\\|\\|",
+			"name": "keyword.operator.concatenator.sql"
+		},
+		{
+			"match": "(?i)\\b(approx_count_distinct|approx_percentile_cont|approx_percentile_disc|avg|checksum_agg|count|count_big|group|grouping|grouping_id|max|min|sum|stdev|stdevp|var|varp)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.aggregate.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(cume_dist|first_value|lag|last_value|lead|percent_rank|percentile_cont|percentile_disc)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.analytic.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(bit_count|get_bit|left_shift|right_shift|set_bit)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.bitmanipulation.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(cast|convert|parse|try_cast|try_convert|try_parse)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.conversion.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(collationproperty|tertiary_weights)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.collation.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(asymkey_id|asymkeyproperty|certproperty|cert_id|crypt_gen_random|decryptbyasymkey|decryptbycert|decryptbykey|decryptbykeyautoasymkey|decryptbykeyautocert|decryptbypassphrase|encryptbyasymkey|encryptbycert|encryptbykey|encryptbypassphrase|hashbytes|is_objectsigned|key_guid|key_id|key_name|signbyasymkey|signbycert|symkeyproperty|verifysignedbycert|verifysignedbyasymkey)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.cryptographic.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(cursor_status)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.cursor.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(sysdatetime|sysdatetimeoffset|sysutcdatetime|current_time(stamp)?|getdate|getutcdate|datename|datepart|day|month|year|datefromparts|datetime2fromparts|datetimefromparts|datetimeoffsetfromparts|smalldatetimefromparts|timefromparts|datediff|dateadd|datetrunc|eomonth|switchoffset|todatetimeoffset|isdate|date_bucket)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.datetime.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(datalength|ident_current|ident_incr|ident_seed|identity|sql_variant_property)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.datatype.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(coalesce|nullif)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.expression.sql"
+				}
+			}
+		},
+		{
+			"match": "(?<!@)@@(?i)\\b(cursor_rows|connections|cpu_busy|datefirst|dbts|error|fetch_status|identity|idle|io_busy|langid|language|lock_timeout|max_connections|max_precision|nestlevel|options|packet_errors|pack_received|pack_sent|procid|remserver|rowcount|servername|servicename|spid|textsize|timeticks|total_errors|total_read|total_write|trancount|version)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.globalvar.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(json|isjson|json_object|json_array|json_value|json_query|json_modify|json_path_exists)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.json.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(choose|iif|greatest|least)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.logical.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(abs|acos|asin|atan|atn2|ceiling|cos|cot|degrees|exp|floor|log|log10|pi|power|radians|rand|round|sign|sin|sqrt|square|tan)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.mathematical.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(app_name|applock_mode|applock_test|assemblyproperty|col_length|col_name|columnproperty|database_principal_id|databasepropertyex|db_id|db_name|file_id|file_idex|file_name|filegroup_id|filegroup_name|filegroupproperty|fileproperty|fulltextcatalogproperty|fulltextserviceproperty|index_col|indexkey_property|indexproperty|object_definition|object_id|object_name|object_schema_name|objectproperty|objectpropertyex|original_db_name|parsename|schema_id|schema_name|scope_identity|serverproperty|stats_date|type_id|type_name|typeproperty)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.metadata.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(rank|dense_rank|ntile|row_number)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.ranking.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(generate_series|opendatasource|openjson|openrowset|openquery|openxml|predict|string_split)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.rowset.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(certencoded|certprivatekey|current_user|database_principal_id|has_perms_by_name|is_member|is_rolemember|is_srvrolemember|original_login|permissions|pwdcompare|pwdencrypt|schema_id|schema_name|session_user|suser_id|suser_sid|suser_sname|system_user|suser_name|user_id|user_name)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.security.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(ascii|char|charindex|concat|difference|format|left|len|lower|ltrim|nchar|nodes|patindex|quotename|replace|replicate|reverse|right|rtrim|soundex|space|str|string_agg|string_escape|string_split|stuff|substring|translate|trim|unicode|upper)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.string.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(binary_checksum|checksum|compress|connectionproperty|context_info|current_request_id|current_transaction_id|decompress|error_line|error_message|error_number|error_procedure|error_severity|error_state|formatmessage|get_filestream_transaction_context|getansinull|host_id|host_name|isnull|isnumeric|min_active_rowversion|newid|newsequentialid|rowcount_big|session_context|session_id|xact_state)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.system.sql"
+				}
+			}
+		},
+		{
+			"match": "(?i)\\b(patindex|textptr|textvalid)\\b\\s*\\(",
+			"captures": {
+				"1": {
+					"name": "support.function.textimage.sql"
+				}
+			}
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "constant.other.database-name.sql"
+				},
+				"2": {
+					"name": "constant.other.table-name.sql"
+				}
+			},
+			"match": "(\\w+?)\\.(\\w+)"
+		},
+		{
+			"include": "#strings"
+		},
+		{
+			"include": "#regexps"
+		},
+		{
+			"match": "\\b(?i)(abort|abort_after_wait|absent|absolute|accent_sensitivity|acceptable_cursopt|acp|action|activation|add|address|admin|aes_128|aes_192|aes_256|affinity|after|aggregate|algorithm|all_constraints|all_errormsgs|all_indexes|all_levels|all_results|allow_connections|allow_dup_row|allow_encrypted_value_modifications|allow_page_locks|allow_row_locks|allow_snapshot_isolation|alter|altercolumn|always|anonymous|ansi_defaults|ansi_null_default|ansi_null_dflt_off|ansi_null_dflt_on|ansi_nulls|ansi_padding|ansi_warnings|appdomain|append|application|apply|arithabort|arithignore|array|assembly|asymmetric|asynchronous_commit|at|atan2|atomic|attach|attach_force_rebuild_log|attach_rebuild_log|audit|auth_realm|authentication|auto|auto_cleanup|auto_close|auto_create_statistics|auto_drop|auto_shrink|auto_update_statistics|auto_update_statistics_async|automated_backup_preference|automatic|autopilot|availability|availability_mode|backup|backup_priority|base64|basic|batches|batchsize|before|between|bigint|binary|binding|bit|block|blockers|blocksize|bmk|both|break|broker|broker_instance|bucket_count|buffer|buffercount|bulk_logged|by|call|caller|card|case|catalog|catch|cert|certificate|change_retention|change_tracking|change_tracking_context|changes|char|character|character_set|check_expiration|check_policy|checkconstraints|checkindex|checkpoint|checksum|cleanup_policy|clear|clear_port|close|clustered|codepage|collection|column_encryption_key|column_master_key|columnstore|columnstore_archive|colv_80_to_100|colv_100_to_80|commit_differential_base|committed|compatibility_level|compress_all_row_groups|compression|compression_delay|concat_null_yields_null|concatenate|configuration|connect|continue|continue_after_error|contract|contract_name|control|conversation|conversation_group_id|conversation_handle|copy|copy_only|count_rows|counter|create(\\\\s+or\\\\s+alter)?|credential|cross|cryptographic|cryptographic_provider|cube|cursor|cursor_close_on_commit|cursor_default|data|data_compression|data_flush_interval_seconds|data_mirroring|data_purity|data_source|database|database_name|database_snapshot|datafiletype|date_correlation_optimization|date|datefirst|dateformat|date_format|datetime|datetime2|datetimeoffset|day(s)?|db_chaining|dbid|dbidexec|dbo_only|deadlock_priority|deallocate|dec|decimal|declare|decrypt|decrypt_a|decryption|default_database|default_language|default_logon_domain|default_schema|definition|delay|delayed_durability|delimitedtext|density_vector|dependent|des|description|desired_state|desx|differential|digest|disable|disable_broker|disable_def_cnst_chk|disabled|disk|distinct|distributed|distribution|drop|drop_existing|dts_buffers|dump|durability|dynamic|edition|elements|else|emergency|empty|enable|enable_broker|enabled|encoding|encrypted|encrypted_value|encryption|encryption_type|end|endpoint|endpoint_url|enhancedintegrity|entry|error_broker_conversations|errorfile|estimateonly|event|except|exec|executable|execute|exists|expand|expiredate|expiry_date|explicit|external|external_access|failover|failover_mode|failure_condition_level|fast|fast_forward|fastfirstrow|federated_service_account|fetch|field_terminator|fieldterminator|file|filelistonly|filegroup|filename|filestream|filestream_log|filestream_on|filetable|file_format|filter|first_row|fips_flagger|fire_triggers|first|firstrow|float|flush_interval_seconds|fmtonly|following|force|force_failover_allow_data_loss|force_service_allow_data_loss|forced|forceplan|formatfile|format_options|format_type|formsof|forward_only|free_cursors|free_exec_context|fullscan|fulltext|fulltextall|fulltextkey|function|generated|get|geography|geometry|global|go|goto|governor|guid|hadoop|hardening|hash|hashed|header_limit|headeronly|health_check_timeout|hidden|hierarchyid|histogram|histogram_steps|hits_cursors|hits_exec_context|hour(s)?|http|identity|identity_value|if|ifnull|ignore|ignore_constraints|ignore_dup_key|ignore_dup_row|ignore_triggers|image|immediate|implicit_transactions|include|include_null_values|index|inflectional|init|initiator|insensitive|insert|instead|int|integer|integrated|intersect|intermediate|interval_length_minutes|into|inuse_cursors|inuse_exec_context|io|is|isabout|iso_week|isolation|job_tracker_location|json|keep|keep_nulls|keep_replication|keepdefaults|keepfixed|keepidentity|keepnulls|kerberos|key|key_path|key_source|key_store_provider_name|keyset|kill|kilobytes_per_batch|labelonly|langid|language|last|lastrow|leading|legacy_cardinality_estimation|length|level|lifetime|lineage_80_to_100|lineage_100_to_80|listener_ip|listener_port|load|loadhistory|lob_compaction|local|local_service_name|locate|location|lock_escalation|lock_timeout|lockres|log|login|login_type|loop|manual|mark_in_use_for_removal|masked|master|matched|max_queue_readers|max_duration|max_outstanding_io_per_volume|maxdop|maxerrors|maxlength|maxtransfersize|max_plans_per_query|max_storage_size_mb|mediadescription|medianame|mediapassword|memogroup|memory_optimized|merge|message|message_forward_size|message_forwarding|microsecond|millisecond|minute(s)?|mirror_address|misses_cursors|misses_exec_context|mixed|modify|money|month|move|multi_user|must_change|name|namespace|nanosecond|native|native_compilation|nchar|ncharacter|never|new_account|new_broker|newname|next|no|no_browsetable|no_checksum|no_compression|no_infomsgs|no_triggers|no_truncate|nocount|noexec|noexpand|noformat|noinit|nolock|nonatomic|nonclustered|nondurable|none|norecompute|norecovery|noreset|norewind|noskip|not|notification|nounload|now|nowait|ntext|ntlm|nulls|numeric|numeric_roundabort|nvarchar|object|objid|oem|offline|old_account|online|operation_mode|open|openjson|optimistic|option|orc|out|outer|output|over|override|owner|ownership|pad_index|page|page_checksum|page_verify|pagecount|paglock|param|parameter_sniffing|parameter_type_expansion|parameterization|parquet|parseonly|partial|partition|partner|password|path|pause|percentage|permission_set|persisted|period|physical_only|plan_forcing_mode|policy|pool|population|ports|preceding|precision|predicate|presume_abort|primary|primary_role|print|prior|priority |priority_level|private|proc(edure)?|procedure_name|profile|provider|quarter|query_capture_mode|query_governor_cost_limit|query_optimizer_hotfixes|query_store|queue|quoted_identifier|raiserror|range|raw|rcfile|rc2|rc4|rc4_128|rdbms|read_committed_snapshot|read|read_only|read_write|readcommitted|readcommittedlock|readonly|readpast|readuncommitted|readwrite|real|rebuild|receive|recmodel_70backcomp|recompile|reconfigure|recovery|recursive|recursive_triggers|redo_queue|reject_sample_value|reject_type|reject_value|relative|remote|remote_data_archive|remote_proc_transactions|remote_service_name|remove|removed_cursors|removed_exec_context|reorganize|repeat|repeatable|repeatableread|replace|replica|replicated|replnick_100_to_80|replnickarray_80_to_100|replnickarray_100_to_80|required|required_cursopt|resample|reset|resource|resource_manager_location|respect|restart|restore|restricted_user|resume|retaindays|retention|return|revert|rewind|rewindonly|returns|robust|role|rollup|root|round_robin|route|row|rowdump|rowguidcol|rowlock|row_terminator|rows|rows_per_batch|rowsets_only|rowterminator|rowversion|rsa_1024|rsa_2048|rsa_3072|rsa_4096|rsa_512|safe|safety|sample|save|scalar|schema|schemabinding|scoped|scroll|scroll_locks|sddl|second|secexpr|secondary|secondary_only|secondary_role|secret|security|securityaudit|selective|self|send|sent|sequence|serde_method|serializable|server|service|service_broker|service_name|service_objective|session_timeout|session|sessions|seterror|setopts|sets|shard_map_manager|shard_map_name|sharded|shared_memory|show_statistics|showplan_all|showplan_text|showplan_xml|showplan_xml_with_recompile|shrinkdb|shutdown|sid|signature|simple|single_blob|single_clob|single_nclob|single_user|singleton|site|size_based_cleanup_mode|skip|smalldatetime|smallint|smallmoney|snapshot|snapshot_import|snapshotrestorephase|soap|softnuma|sort_in_tempdb|sorted_data|sorted_data_reorg|spatial|sql|sql_bigint|sql_binary|sql_bit|sql_char|sql_date|sql_decimal|sql_double|sql_float|sql_guid|sql_handle|sql_longvarbinary|sql_longvarchar|sql_numeric|sql_real|sql_smallint|sql_time|sql_timestamp|sql_tinyint|sql_tsi_day|sql_tsi_frac_second|sql_tsi_hour|sql_tsi_minute|sql_tsi_month|sql_tsi_quarter|sql_tsi_second|sql_tsi_week|sql_tsi_year|sql_type_date|sql_type_time|sql_type_timestamp|sql_varbinary|sql_varchar|sql_variant|sql_wchar|sql_wlongvarchar|ssl|ssl_port|standard|standby|start|start_date|started|stat_header|state|statement|static|statistics|statistics_incremental|statistics_norecompute|statistics_only|statman|stats|stats_stream|status|stop|stop_on_error|stopat|stopatmark|stopbeforemark|stoplist|stopped|string_delimiter|subject|supplemental_logging|supported|suspend|symmetric|synchronous_commit|synonym|sysname|system|system_time|system_versioning|table|tableresults|tablock|tablockx|take|tape|target|target_index|target_partition|tcp|temporal_history_retention|text|textimage_on|then|thesaurus|throw|time|timeout|timestamp|tinyint|to|top|torn_page_detection|track_columns_updated|trailing|tran|transaction|transfer|triple_des|triple_des_3key|truncate|trustworthy|try|tsql|type|type_desc|type_warning|tzoffset|uid|unbounded|uncommitted|unique|uniqueidentifier|unlimited|unload|unlock|unsafe|updlock|url|use|useplan|useroptions|use_type_default|using|utcdatetime|valid_xml|validation|value|values|varbinary|varchar|verbose|verifyonly|version|view_metadata|virtual_device|visiblity|wait_at_low_priority|waitfor|webmethod|week|weekday|weight|well_formed_xml|when|while|widechar|widechar_ansi|widenative|window|windows|with|within|within group|witness|without|without_array_wrapper|workload|wsdl|xact_abort|xlock|xml|xmlschema|xquery|xsinil|year|zone)\\b",
+			"name": "keyword.other.sql"
+		},
+		{
+			"captures": {
+				"1": {
+					"name": "punctuation.section.scope.begin.sql"
+				},
+				"2": {
+					"name": "punctuation.section.scope.end.sql"
+				}
+			},
+			"comment": "Allow for special ↩ behavior",
+			"match": "(\\()(\\))",
+			"name": "meta.block.sql"
+		}
+	],
+	"repository": {
+        "keywordsStorage": {
+            "patterns": [
+              {
+                "name": "keyword.control",
+                "match": ":(PUBLIC|DECLARE|CLASS|INHERIT|INCLUDE|PARAMETERS|PROCEDURE|ENDPROC|REGION|ENDREGION|BEGININLINECODE|ENDINLINECODE|ERROR)\\b"
+              }
+            ]
+          },
+		"comments": {
+			"patterns": [
+				{
+					"begin": "(^[ \\t]+)?(?=--)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.whitespace.comment.leading.sql"
+						}
+					},
+					"end": "(?!\\G)",
+					"patterns": [
+						{
+							"begin": "--",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.comment.sql"
+								}
+							},
+							"end": "\\n",
+							"name": "comment.line.double-dash.sql"
+						}
+					]
+				},
+				{
+					"begin": "(^[ \\t]+)?(?=#)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.whitespace.comment.leading.sql"
+						}
+					},
+					"end": "(?!\\G)",
+					"patterns": []
+				},
+				{
+					"begin": "/\\*",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.sql"
+						}
+					},
+					"end": "\\*/",
+					"name": "comment.block.c"
+				}
+			]
+		},
+		"regexps": {
+			"patterns": [
+				{
+					"begin": "/(?=\\S.*/)",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.sql"
+						}
+					},
+					"end": "/",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.sql"
+						}
+					},
+					"name": "string.regexp.sql",
+					"patterns": [
+						{
+							"include": "#string_interpolation"
+						},
+						{
+							"match": "\\\\/",
+							"name": "constant.character.escape.slash.sql"
+						}
+					]
+				},
+				{
+					"begin": "%r\\{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.sql"
+						}
+					},
+					"comment": "We should probably handle nested bracket pairs!?! -- Allan",
+					"end": "\\}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.sql"
+						}
+					},
+					"name": "string.regexp.modr.sql",
+					"patterns": [
+						{
+							"include": "#string_interpolation"
+						}
+					]
+				}
+			]
+		},
+		"string_escape": {
+			"match": "\\\\.",
+			"name": "constant.character.escape.sql"
+		},
+		"string_interpolation": {
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.string.begin.sql"
+				},
+				"3": {
+					"name": "punctuation.definition.string.end.sql"
+				}
+			},
+			"match": "(#\\{)([^\\}]*)(\\})",
+			"name": "string.interpolated.sql"
+		},
+		"strings": {
+			"patterns": [
+				{
+					"captures": {
+						"2": {
+							"name": "punctuation.definition.string.begin.sql"
+						},
+						"3": {
+							"name": "punctuation.definition.string.end.sql"
+						}
+					},
+					"comment": "this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.",
+					"match": "(N)?(')[^']*(')",
+					"name": "string.quoted.single.sql"
+				},
+				{
+					"begin": "'",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.sql"
+						}
+					},
+					"end": "'",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.sql"
+						}
+					},
+					"name": "string.quoted.single.sql",
+					"patterns": [
+						{
+							"include": "#string_escape"
+						}
+					]
+				},
+				{
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.sql"
+						},
+						"2": {
+							"name": "punctuation.definition.string.end.sql"
+						}
+					},
+					"comment": "this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.",
+					"match": "(`)[^`\\\\]*(`)",
+					"name": "string.quoted.other.backtick.sql"
+				},
+				{
+					"begin": "`",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.sql"
+						}
+					},
+					"end": "`",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.sql"
+						}
+					},
+					"name": "string.quoted.other.backtick.sql",
+					"patterns": [
+						{
+							"include": "#string_escape"
+						}
+					]
+				},
+				{
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.sql"
+						},
+						"2": {
+							"name": "punctuation.definition.string.end.sql"
+						}
+					},
+					"comment": "this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.",
+					"match": "(\")[^\"#]*(\")",
+					"name": "string.quoted.double.sql"
+				},
+				{
+					"begin": "\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.sql"
+						}
+					},
+					"end": "\"",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.sql"
+						}
+					},
+					"name": "string.quoted.double.sql",
+					"patterns": [
+						{
+							"include": "#string_interpolation"
+						}
+					]
+				},
+				{
+					"begin": "%\\{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.sql"
+						}
+					},
+					"end": "\\}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.sql"
+						}
+					},
+					"name": "string.other.quoted.brackets.sql",
+					"patterns": [
+						{
+							"include": "#string_interpolation"
+						}
+					]
+				}
+			]
+		}
+	}
+}

--- a/syntaxes/ssl.tmLanguage.json
+++ b/syntaxes/ssl.tmLanguage.json
@@ -24,7 +24,7 @@
     "keywordsStorage": {
       "patterns": [
         {
-          "name": "storage.type",
+          "name": "keyword.control",
           "match": ":(PUBLIC|DECLARE|CLASS|INHERIT|INCLUDE|PARAMETERS|PROCEDURE|ENDPROC|REGION|ENDREGION|BEGININLINECODE|ENDINLINECODE|ERROR)\\b"
         }
       ]
@@ -38,10 +38,13 @@
           "include": "#embeddedSql"
         },
         {
-          "include": "#iif"
+          "include": "#embeddedSqlString"
         },
         {
           "include": "#blueFunctions"
+        },
+        {
+          "include": "#navigatorVars"
         },
         {
           "include": "#function"
@@ -72,13 +75,19 @@
         },
         {
           "include": "#langConstants"
+        },
+        {
+          "include": "#langNavigatorVars"
+        },
+        {
+          "include": "#variableInSQLString"
         }
       ]
     },
     "comment": {
       "name": "comment.block.srvsrc",
       "begin": "/\\*",
-      "end": ";"
+      "end": "\\*/|;"
     },
     "identifier": {
       "patterns": [
@@ -113,8 +122,8 @@
     },
     "blueFunctions": {
       "name": "support.function",
-      "begin": "(?i)\\b(DoProc|ExecFunction|ExecUdf|CreateUDObject|Branch|aadd|aeval|aevala|afill|alen|arraycalc|arraynew|ascan|ascanexact|buildarray|buildarray2|buildstring|buildstring2|BuildStringForIn|comparray|delarray|extractcol|PrepareArrayForIn|SortArray|ArrayToTVP|deleteinlinecode|endlimsoleconnect|getinlinecode|getregion|In64BitMode|Let|LimsCleanup|LimsNETConnect|LimsNETTypeOf|limsoleconnect|MakeNETObject|StationName|BeginLimsTransaction|DetectSqlInjections|EndLimsTransaction|GetConnectionByName|GetConnectionStrings|GetDataSet|GetDataSetEx|GetDataSetFromArray|GetDataSetFromArrayEx|GetDataSetWithSchemaFromSelect|GetDataSetXMLFromArray|GetDataSetXMLFromSelect|GetDBMSName|GetDBMSProviderName|GetDefaultConnection|GetLastSQLError|GetNETDataSet|GetNoLock|GetTables|GetTransactionsCount|IgnoreSqlErrors|IsDBConnected|IsInTransaction|IsTable|IsTableFld|LimsRecordsAffected|LimsSetCounter|LimsSqlConnect|LimsSqlDisconnect|LSearch|LSelect|LSelect1|LSelectC|RetrieveLong|ReturnLastSQLError|RunSQL|SetDefaultConnection|SetSqlTimeout|ShowSqlErrors|SQLExecute|SQLRemoveComments|TableFldLst|UpdLong|GetDSParameters|GetSSLDataset|RunDS|IsDefined|IsHex|LFromHex|LHex2Dec|LimsNETCast|LimsType|LimsTypeEx|LToHex|ClientEndOfDay|ClientStartOfDay|CMonth|CToD|DateAdd|DateDiff|DateDiffEx|DateFormat|DateFromNumbers|DateFromString|DateToString|Day|DOW|DOY|DToC|DToS|Hour|IsInvariantDate|JDay|LIMSDate|LimsGetDateFormat|LimsTime|MakeDateInvariant|MakeDateLocal|Minute|Month|NoOfDays|Now|Second|Seconds|ServerEndOfDay|ServerStartOfDay|ServerTimeZone|SetAmPm|StringToDate|Time|Today|UserTimeZone|ValidateDate|Year|SendFromOutbox|SendLimsEmail|SendOutlookReminder|SendToOutbox|ClearLastSSLError|FormatErrorMessage|FormatSqlErrorMessage|GetLastSSLError|RaiseError|CombineFiles|Directory|DosSupport|FileSupport|lDir|ReadBytesBase64|ReadText|WriteBytesBase64|WriteText|CheckOnFtp|CopyToFtp|DeleteDirOnFtp|DeleteFromFtp|GetDirFromFtp|GetFromFtp|MakeDirOnFtp|MoveInFtp|ReadFromFtp|RenameOnFtp|SendToFtp|WriteToFtp|MergeHtmlForm|Break|Compress|CreateGUID|CreateLocal|CreatePublic|CreateZip|Decompress|ErrorMes|ExtractZip|GetAppBaseFolder|GetAppWorkPathFolder|GetByName|GetExecutionTrace|GetFeaturesAndNumbers|GetFileVersion|GetForbiddenAppIDs|GetForbiddenDesignerAppIDs|GetInstallationKey|GetLicenseInfoAsText|GetLogsFolder|GetNumberOfInstrumentConnections|GetNumberOfNamedConcurrentUsers|GetNumberOfNamedUsers|GetPrinters|GetSetting|GetSettings|GetSystemLayerId|GetWebFolder|IIf|InBatchProcess|InfoMes|IsDemoLicense|IsFeatureAuthorized|IsFeatureBasedLicense|IsGuid|IsProductionModeOn|LCase|LKill|NetFrameworkVersion|Nothing|ResetApplication|ResetFeatures|SetByName|SqlTraceOff|SqlTraceOn|TryConnect|usrmes|bs|GetDecimalSep|GetDecimalSeparator|GetGroupSeparator|Integer|IsNumeric|LimsXOr|MatFunc|Max|Min|Rand|Round|RoundPoint5|Scient|SetDecimalSeparator|SetGroupSeparator|SigFig|Sqrt|StdRound|ToNumeric|ToScientific|Val|ValidateNumeric|LimsExec|lWait|PrmCount|RunApp|SubmitToBatch|SubmitToBatchEx|TraceOff|TraceOn|UndeclaredVars|LPrint|SetLocationOracle|SetLocationSQLServer|ConvertReport|ChkNewPassword|ChkPassword|DecryptData|EncryptData|GetUserData|HashData|LDAPAuth|LDAPAuthEX|SearchLDAPUser|SetUserData|SetUserPassword|VerifySignature|ValidateFieldData|ValidateData|ValidateDSParams|AllTrim|Asc|At|Chr|Empty|Left|Len|LimsAt|LimsString|LLower|Lower|LStr|LTransform|LTrim|MimeDecode|MimeEncode|Rat|Replace|Replicate|Right|Seval|Str|StringAdd|StringClean|StringCreate|StringGet|StringKill|StrSrch|StrTran|StrZero|SubStr|Trim|Upper|GetAllClientScripts|MergeGlobalResources|PrepareForm|PrepareFormClientScript|ProcessXfdFormForImport|SyncDesignResources|SyncProgramaticResourcesAddProperty|ExecInternal|GetInternal|GetInternalC|HasProperty|SetInternal|SetInternalC|AddToApplication|AddToSession|ClearSession|FromJson|GetFromApplication|GetFromSession|ToJson|UrlDecode|UrlEncodeGetClientScriptReferences|GetFormReferences|MergeXfd|FromXml|HtmlDecode|HtmlEncode|ToXml|XmlDomToUdObject)(\\()",
-      "end": "\\)",
+      "begin": "(?i)(Iif|DoProc|ExecFunction|ExecUdf|CreateUDObject|Branch|aadd|aeval|aevala|afill|alen|arraycalc|arraynew|ascan|ascanexact|buildarray|buildarray2|buildstring|buildstring2|BuildStringForIn|comparray|delarray|extractcol|PrepareArrayForIn|SortArray|ArrayToTVP|deleteinlinecode|endlimsoleconnect|getinlinecode|getregion|In64BitMode|Let|LimsCleanup|LimsNETConnect|LimsNETTypeOf|limsoleconnect|MakeNETObject|StationName|BeginLimsTransaction|DetectSqlInjections|EndLimsTransaction|GetConnectionByName|GetConnectionStrings|GetDataSet|GetDataSetEx|GetDataSetFromArray|GetDataSetFromArrayEx|GetDataSetWithSchemaFromSelect|GetDataSetXMLFromArray|GetDataSetXMLFromSelect|GetDBMSName|GetDBMSProviderName|GetDefaultConnection|GetLastSQLError|GetNETDataSet|GetNoLock|GetTables|GetTransactionsCount|IgnoreSqlErrors|IsDBConnected|IsInTransaction|IsTable|IsTableFld|LimsRecordsAffected|LimsSetCounter|LimsSqlConnect|LimsSqlDisconnect|LSearch|LSelect|LSelect1|LSelectC|RetrieveLong|ReturnLastSQLError|RunSQL|SetDefaultConnection|SetSqlTimeout|ShowSqlErrors|SQLExecute|SQLRemoveComments|TableFldLst|UpdLong|GetDSParameters|GetSSLDataset|RunDS|IsDefined|IsHex|LFromHex|LHex2Dec|LimsNETCast|LimsType|LimsTypeEx|LToHex|ClientEndOfDay|ClientStartOfDay|CMonth|CToD|DateAdd|DateDiff|DateDiffEx|DateFormat|DateFromNumbers|DateFromString|DateToString|Day|DOW|DOY|DToC|DToS|Hour|IsInvariantDate|JDay|LIMSDate|LimsGetDateFormat|LimsTime|MakeDateInvariant|MakeDateLocal|Minute|Month|NoOfDays|Now|Second|Seconds|ServerEndOfDay|ServerStartOfDay|ServerTimeZone|SetAmPm|StringToDate|Time|Today|UserTimeZone|ValidateDate|Year|SendFromOutbox|SendLimsEmail|SendOutlookReminder|SendToOutbox|ClearLastSSLError|FormatErrorMessage|FormatSqlErrorMessage|GetLastSSLError|RaiseError|CombineFiles|Directory|DosSupport|FileSupport|lDir|ReadBytesBase64|ReadText|WriteBytesBase64|WriteText|CheckOnFtp|CopyToFtp|DeleteDirOnFtp|DeleteFromFtp|GetDirFromFtp|GetFromFtp|MakeDirOnFtp|MoveInFtp|ReadFromFtp|RenameOnFtp|SendToFtp|WriteToFtp|MergeHtmlForm|Break|Compress|CreateGUID|CreateLocal|CreatePublic|CreateZip|Decompress|ErrorMes|ExtractZip|GetAppBaseFolder|GetAppWorkPathFolder|GetByName|GetExecutionTrace|GetFeaturesAndNumbers|GetFileVersion|GetForbiddenAppIDs|GetForbiddenDesignerAppIDs|GetInstallationKey|GetLicenseInfoAsText|GetLogsFolder|GetNumberOfInstrumentConnections|GetNumberOfNamedConcurrentUsers|GetNumberOfNamedUsers|GetPrinters|GetSetting|GetSettings|GetSystemLayerId|GetWebFolder|IIf|InBatchProcess|InfoMes|IsDemoLicense|IsFeatureAuthorized|IsFeatureBasedLicense|IsGuid|IsProductionModeOn|LCase|LKill|NetFrameworkVersion|Nothing|ResetApplication|ResetFeatures|SetByName|SqlTraceOff|SqlTraceOn|TryConnect|usrmes|bs|GetDecimalSep|GetDecimalSeparator|GetGroupSeparator|Integer|IsNumeric|LimsXOr|MatFunc|Max|Min|Rand|Round|RoundPoint5|Scient|SetDecimalSeparator|SetGroupSeparator|SigFig|Sqrt|StdRound|ToNumeric|ToScientific|Val|ValidateNumeric|LimsExec|lWait|PrmCount|RunApp|SubmitToBatch|SubmitToBatchEx|TraceOff|TraceOn|UndeclaredVars|LPrint|SetLocationOracle|SetLocationSQLServer|ConvertReport|ChkNewPassword|ChkPassword|DecryptData|EncryptData|GetUserData|HashData|LDAPAuth|LDAPAuthEX|SearchLDAPUser|SetUserData|SetUserPassword|VerifySignature|ValidateFieldData|ValidateData|ValidateDSParams|AllTrim|Asc|At|Chr|Empty|Left|Len|LimsAt|LimsString|LLower|Lower|LStr|LTransform|LTrim|MimeDecode|MimeEncode|Rat|Replace|Replicate|Right|Seval|Str|StringAdd|StringClean|StringCreate|StringGet|StringKill|StrSrch|StrTran|StrZero|SubStr|Trim|Upper|GetAllClientScripts|MergeGlobalResources|PrepareForm|PrepareFormClientScript|ProcessXfdFormForImport|SyncDesignResources|SyncProgramaticResourcesAddProperty|ExecInternal|GetInternal|GetInternalC|HasProperty|SetInternal|SetInternalC|AddToApplication|AddToSession|ClearSession|FromJson|GetFromApplication|GetFromSession|ToJson|UrlDecode|UrlEncodeGetClientScriptReferences|GetFormReferences|MergeXfd|FromXml|HtmlDecode|HtmlEncode|ToXml|XmlDomToUdObject)\\(",
+      "end": "(?<!\\.)",
       "patterns": [
         {
           "include": "#expression"
@@ -130,48 +139,14 @@
         }
       ]
     },
-    "iif": {
-      "name": "support.function",
-      "begin": "\\b(iif)(\\()",
-      "end": "\\)",
-      "patterns": [
-        {
-          "include": "#expression"
-        },
-        {
-          "begin": ",",
-          "end": "(?=,)|(?=\\))",
-          "patterns": [
-            {
-              "include": "#expression"
-            }
-          ]
-        }
-      ]
-    },
-    "iif_in_sql": {
-      "name": "support.function",
-      "begin": "\\b(iif)(\\()",
-      "end": "\\)",
-      "patterns": [
-        {
-          "include": "#expression"
-        },
-        {
-          "begin": ",",
-          "end": "(?=,)|(?=\\))",
-          "patterns": [
-            {
-              "include": "#expression_in_sql"
-            }
-          ]
-        }
-      ]
+    "navigatorVars": {
+      "name": "variable.other.constant",
+      "match": "(?i)(MYUSERNAME|STARLIMSDEPT|MYUSERROLE)"
     },
     "function": {
       "begin": "\\b[a-zA-Z_][a-zA-Z0-9_]*(\\()",
       "end": "\\)",
-      "name": "entity.name.function",
+      "name": "support.function",
       "patterns": [
         {
           "include": "#expression"
@@ -188,8 +163,8 @@
       ]
     },
     "langConstants": {
-      "name": "constant.language",
-      "match": "\\.(t|T|f|F)\\."
+      "name": "constant.character.escape",
+      "match": "(?i)\\.(t|T|f|F)\\."
     },
     "numbers": {
       "name": "constant.numeric",
@@ -209,92 +184,40 @@
       ]
     },
     "stringsDouble": {
-      "name": "string.quoted.double",
+      "name": "meta.preprocessor.string",
       "begin": "\"",
       "end": "\""
     },
     "stringsSingle": {
-      "name": "string.quoted.sinlge",
+      "name": "meta.preprocessor.string",
       "begin": "'",
       "end": "'"
     },
-    "embeddedSql": {
-      "begin": "(?i)(GetDataSet|GetDataSetEx|SqlExecute|RunSql|LSearch|LSelect|SqlUtils:GetUDo)\\s*\\(\\s*",
-      "end": "\\)|,",
-      "name": "support.function",
-      "patterns": [
-        {
-          "include": "#expression_in_sql"
-        },
-        {
-          "begin": ",",
-          "end": "(?=,)|(?=\\))",
-          "patterns": [
-            {
-              "include": "#expression"
-            }
-          ]
-        }
-      ]
+    "variableInSQLString": {
+      "match": "\\?",
+      "name": "meta.preprocessor.string"
     },
-    "expression_in_sql": {
-      "patterns": [
-        {
-          "include": "#comment"
+    "embeddedSqlString": {
+      "begin": "(?i)(\")(select|insert|update|delete|create|drop|alter|truncate|grant|revoke|commit|rollback|set|declare|begin|call|execute|prepare|open|fetch|lock|unlock|merge|rename|replace|purge)\\s+",
+      "end": "(\")",
+      "name": "source.sql",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword"
         },
-        {
-          "include": "#embeddedSqlStringsDouble"
-        },
-        {
-          "include": "#embeddedSqlStringsSingle"
-        },
-        {
-          "include": "#embeddedSql"
-        },
-        {
-          "include": "#iif_in_sql"
-        },
-        {
-          "include": "#blueFunctions"
-        },
-        {
-          "include": "#function"
-        },
-        {
-          "include": "#identifier_accessed"
-        },
-        {
-          "include": "#identifier"
-        },
-        {
-          "include": "#operator"
-        },
-        {
-          "include": "#numbers"
-        },
-        {
-          "include": "#array"
-        },
-        {
-          "include": "#langConstants"
+        "1": {
+          "name": "string.quoted.double.sql"
         }
-      ]
-    },
-    "embeddedSqlStringsDouble": {
-      "name": "meta.embedded.block.sql",
-      "begin": "\"",
-      "end": "\"",
+      },
+      "endCaptures": {
+        "0": {
+          "name": "string.quoted.double.sql"
+        }
+      },
       "patterns": [
         {
-          "include": "source.sql"
-        }
-      ]
-    },
-    "embeddedSqlStringsSingle": {
-      "name": "meta.embedded.block.sql",
-      "begin": "'",
-      "end": "'",
-      "patterns": [
+          "include": "#variableInSQLString"
+        },
         {
           "include": "source.sql"
         }

--- a/syntaxes/ssl.tmLanguage.json
+++ b/syntaxes/ssl.tmLanguage.json
@@ -90,7 +90,7 @@
     "comment": {
       "name": "comment.block.srvsrc",
       "begin": "/\\*",
-      "end": "\\*/|;"
+      "end": "\\*/;"
     },
     "identifier": {
       "patterns": [
@@ -230,7 +230,7 @@
       "end": "\""
     },
     "stringsSingle": {
-      "name": "string.quoted.sinlge",
+      "name": "string.quoted.single",
       "begin": "'",
       "end": "'"
     },

--- a/syntaxes/ssl.tmLanguage.json
+++ b/syntaxes/ssl.tmLanguage.json
@@ -16,7 +16,7 @@
     "keywordsControl": {
       "patterns": [
         {
-          "name": "keyword.control",
+          "name": "starlims.ssl.keyword.control",
           "match": ":(BEGINCASE|CASE|ENDCASE|EXITCASE|OTHERWISE|IF|DEFAULT|REGION|ENDREGION|ENDIF|ELSE|LOOP|WHILE|ENDWHILE|FOR|NEXT|STEP|EXITFOR|RESUME|CASE|EXITCASE|RETURN|TRY|CATCH|FINALLY|ENDTRY|TO)\\b"
         }
       ]
@@ -24,7 +24,7 @@
     "keywordsStorage": {
       "patterns": [
         {
-          "name": "keyword.control",
+          "name": "starlims.ssl.keyword.storage",
           "match": ":(PUBLIC|DECLARE|CLASS|INHERIT|INCLUDE|PARAMETERS|PROCEDURE|ENDPROC|REGION|ENDREGION|BEGININLINECODE|ENDINLINECODE|ERROR)\\b"
         }
       ]
@@ -39,6 +39,9 @@
         },
         {
           "include": "#embeddedSqlString"
+        },
+        {
+          "include": "#iif"
         },
         {
           "include": "#blueFunctions"
@@ -92,7 +95,7 @@
     "identifier": {
       "patterns": [
         {
-          "name": "variables.other",
+          "name": "variable",
           "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*(?!\\()"
         }
       ]
@@ -100,7 +103,7 @@
     "identifier_accessed": {
       "patterns": [
         {
-          "name": "variables.other",
+          "name": "variable",
           "begin": "\\b[a-zA-Z_][a-zA-Z0-9_]*(\\[)",
           "end": "\\]",
           "patterns": [
@@ -121,8 +124,8 @@
       ]
     },
     "blueFunctions": {
-      "name": "support.function",
-      "begin": "(?i)(Iif|DoProc|ExecFunction|ExecUdf|CreateUDObject|Branch|aadd|aeval|aevala|afill|alen|arraycalc|arraynew|ascan|ascanexact|buildarray|buildarray2|buildstring|buildstring2|BuildStringForIn|comparray|delarray|extractcol|PrepareArrayForIn|SortArray|ArrayToTVP|deleteinlinecode|endlimsoleconnect|getinlinecode|getregion|In64BitMode|Let|LimsCleanup|LimsNETConnect|LimsNETTypeOf|limsoleconnect|MakeNETObject|StationName|BeginLimsTransaction|DetectSqlInjections|EndLimsTransaction|GetConnectionByName|GetConnectionStrings|GetDataSet|GetDataSetEx|GetDataSetFromArray|GetDataSetFromArrayEx|GetDataSetWithSchemaFromSelect|GetDataSetXMLFromArray|GetDataSetXMLFromSelect|GetDBMSName|GetDBMSProviderName|GetDefaultConnection|GetLastSQLError|GetNETDataSet|GetNoLock|GetTables|GetTransactionsCount|IgnoreSqlErrors|IsDBConnected|IsInTransaction|IsTable|IsTableFld|LimsRecordsAffected|LimsSetCounter|LimsSqlConnect|LimsSqlDisconnect|LSearch|LSelect|LSelect1|LSelectC|RetrieveLong|ReturnLastSQLError|RunSQL|SetDefaultConnection|SetSqlTimeout|ShowSqlErrors|SQLExecute|SQLRemoveComments|TableFldLst|UpdLong|GetDSParameters|GetSSLDataset|RunDS|IsDefined|IsHex|LFromHex|LHex2Dec|LimsNETCast|LimsType|LimsTypeEx|LToHex|ClientEndOfDay|ClientStartOfDay|CMonth|CToD|DateAdd|DateDiff|DateDiffEx|DateFormat|DateFromNumbers|DateFromString|DateToString|Day|DOW|DOY|DToC|DToS|Hour|IsInvariantDate|JDay|LIMSDate|LimsGetDateFormat|LimsTime|MakeDateInvariant|MakeDateLocal|Minute|Month|NoOfDays|Now|Second|Seconds|ServerEndOfDay|ServerStartOfDay|ServerTimeZone|SetAmPm|StringToDate|Time|Today|UserTimeZone|ValidateDate|Year|SendFromOutbox|SendLimsEmail|SendOutlookReminder|SendToOutbox|ClearLastSSLError|FormatErrorMessage|FormatSqlErrorMessage|GetLastSSLError|RaiseError|CombineFiles|Directory|DosSupport|FileSupport|lDir|ReadBytesBase64|ReadText|WriteBytesBase64|WriteText|CheckOnFtp|CopyToFtp|DeleteDirOnFtp|DeleteFromFtp|GetDirFromFtp|GetFromFtp|MakeDirOnFtp|MoveInFtp|ReadFromFtp|RenameOnFtp|SendToFtp|WriteToFtp|MergeHtmlForm|Break|Compress|CreateGUID|CreateLocal|CreatePublic|CreateZip|Decompress|ErrorMes|ExtractZip|GetAppBaseFolder|GetAppWorkPathFolder|GetByName|GetExecutionTrace|GetFeaturesAndNumbers|GetFileVersion|GetForbiddenAppIDs|GetForbiddenDesignerAppIDs|GetInstallationKey|GetLicenseInfoAsText|GetLogsFolder|GetNumberOfInstrumentConnections|GetNumberOfNamedConcurrentUsers|GetNumberOfNamedUsers|GetPrinters|GetSetting|GetSettings|GetSystemLayerId|GetWebFolder|IIf|InBatchProcess|InfoMes|IsDemoLicense|IsFeatureAuthorized|IsFeatureBasedLicense|IsGuid|IsProductionModeOn|LCase|LKill|NetFrameworkVersion|Nothing|ResetApplication|ResetFeatures|SetByName|SqlTraceOff|SqlTraceOn|TryConnect|usrmes|bs|GetDecimalSep|GetDecimalSeparator|GetGroupSeparator|Integer|IsNumeric|LimsXOr|MatFunc|Max|Min|Rand|Round|RoundPoint5|Scient|SetDecimalSeparator|SetGroupSeparator|SigFig|Sqrt|StdRound|ToNumeric|ToScientific|Val|ValidateNumeric|LimsExec|lWait|PrmCount|RunApp|SubmitToBatch|SubmitToBatchEx|TraceOff|TraceOn|UndeclaredVars|LPrint|SetLocationOracle|SetLocationSQLServer|ConvertReport|ChkNewPassword|ChkPassword|DecryptData|EncryptData|GetUserData|HashData|LDAPAuth|LDAPAuthEX|SearchLDAPUser|SetUserData|SetUserPassword|VerifySignature|ValidateFieldData|ValidateData|ValidateDSParams|AllTrim|Asc|At|Chr|Empty|Left|Len|LimsAt|LimsString|LLower|Lower|LStr|LTransform|LTrim|MimeDecode|MimeEncode|Rat|Replace|Replicate|Right|Seval|Str|StringAdd|StringClean|StringCreate|StringGet|StringKill|StrSrch|StrTran|StrZero|SubStr|Trim|Upper|GetAllClientScripts|MergeGlobalResources|PrepareForm|PrepareFormClientScript|ProcessXfdFormForImport|SyncDesignResources|SyncProgramaticResourcesAddProperty|ExecInternal|GetInternal|GetInternalC|HasProperty|SetInternal|SetInternalC|AddToApplication|AddToSession|ClearSession|FromJson|GetFromApplication|GetFromSession|ToJson|UrlDecode|UrlEncodeGetClientScriptReferences|GetFormReferences|MergeXfd|FromXml|HtmlDecode|HtmlEncode|ToXml|XmlDomToUdObject)\\(",
+      "name": "starlims.blue-function",
+      "begin": "(?i)(Iif|DoProc|ExecFunction|ExecUdf|CreateUDObject|Branch|aadd|aeval|aevala|afill|alen|arraycalc|arraynew|ascan|ascanexact|buildarray|buildarray2|buildstring|buildstring2|BuildStringForIn|comparray|delarray|extractcol|PrepareArrayForIn|SortArray|ArrayToTVP|deleteinlinecode|endlimsoleconnect|getinlinecode|getregion|In64BitMode|Let|LimsCleanup|LimsNETConnect|LimsNETTypeOf|limsoleconnect|MakeNETObject|StationName|BeginLimsTransaction|DetectSqlInjections|EndLimsTransaction|GetConnectionByName|GetConnectionStrings|GetDataSet|GetDataSetEx|GetDataSetFromArray|GetDataSetFromArrayEx|GetDataSetWithSchemaFromSelect|GetDataSetXMLFromArray|GetDataSetXMLFromSelect|GetDBMSName|GetDBMSProviderName|GetDefaultConnection|GetLastSQLError|GetNETDataSet|GetNoLock|GetTables|GetTransactionsCount|IgnoreSqlErrors|IsDBConnected|IsInTransaction|IsTable|IsTableFld|LimsRecordsAffected|LimsSetCounter|LimsSqlConnect|LimsSqlDisconnect|LSearch|LSelect|LSelect1|LSelectC|RetrieveLong|ReturnLastSQLError|RunSQL|SetDefaultConnection|SetSqlTimeout|ShowSqlErrors|SQLExecute|SQLRemoveComments|TableFldLst|UpdLong|GetDSParameters|GetSSLDataset|RunDS|IsDefined|IsHex|LFromHex|LHex2Dec|LimsNETCast|LimsType|LimsTypeEx|LToHex|ClientEndOfDay|ClientStartOfDay|CMonth|CToD|DateAdd|DateDiff|DateDiffEx|DateFormat|DateFromNumbers|DateFromString|DateToString|Day|DOW|DOY|DToC|DToS|Hour|IsInvariantDate|JDay|LIMSDate|LimsGetDateFormat|LimsTime|MakeDateInvariant|MakeDateLocal|Minute|Month|NoOfDays|Now|Second|Seconds|ServerEndOfDay|ServerStartOfDay|ServerTimeZone|SetAmPm|StringToDate|Time|Today|UserTimeZone|ValidateDate|Year|SendFromOutbox|SendLimsEmail|SendOutlookReminder|SendToOutbox|ClearLastSSLError|FormatErrorMessage|FormatSqlErrorMessage|GetLastSSLError|RaiseError|CombineFiles|Directory|DosSupport|FileSupport|lDir|ReadBytesBase64|ReadText|WriteBytesBase64|WriteText|CheckOnFtp|CopyToFtp|DeleteDirOnFtp|DeleteFromFtp|GetDirFromFtp|GetFromFtp|MakeDirOnFtp|MoveInFtp|ReadFromFtp|RenameOnFtp|SendToFtp|WriteToFtp|MergeHtmlForm|Break|Compress|CreateGUID|CreateLocal|CreatePublic|CreateZip|Decompress|ErrorMes|ExtractZip|GetAppBaseFolder|GetAppWorkPathFolder|GetByName|GetExecutionTrace|GetFeaturesAndNumbers|GetFileVersion|GetForbiddenAppIDs|GetForbiddenDesignerAppIDs|GetInstallationKey|GetLicenseInfoAsText|GetLogsFolder|GetNumberOfInstrumentConnections|GetNumberOfNamedConcurrentUsers|GetNumberOfNamedUsers|GetPrinters|GetSetting|GetSettings|GetSystemLayerId|GetWebFolder|IIf|InBatchProcess|InfoMes|IsDemoLicense|IsFeatureAuthorized|IsFeatureBasedLicense|IsGuid|IsProductionModeOn|LCase|LKill|NetFrameworkVersion|Nothing|ResetApplication|ResetFeatures|SetByName|SqlTraceOff|SqlTraceOn|TryConnect|usrmes|bs|GetDecimalSep|GetDecimalSeparator|GetGroupSeparator|Integer|IsNumeric|LimsXOr|MatFunc|Max|Min|Rand|Round|RoundPoint5|Scient|SetDecimalSeparator|SetGroupSeparator|SigFig|Sqrt|StdRound|ToNumeric|ToScientific|Val|ValidateNumeric|LimsExec|lWait|PrmCount|RunApp|SubmitToBatch|SubmitToBatchEx|TraceOff|TraceOn|UndeclaredVars|LPrint|SetLocationOracle|SetLocationSQLServer|ConvertReport|ChkNewPassword|ChkPassword|DecryptData|EncryptData|GetUserData|HashData|LDAPAuth|LDAPAuthEX|SearchLDAPUser|SetUserData|SetUserPassword|VerifySignature|ValidateFieldData|ValidateData|ValidateDSParams|AllTrim|Asc|At|Chr|Empty|Left|Len|LimsAt|LimsString|LLower|Lower|LStr|LTransform|LTrim|MimeDecode|MimeEncode|Rat|Replace|Replicate|Right|Seval|Str|StringAdd|StringClean|StringCreate|StringGet|StringKill|StrSrch|StrTran|StrZero|SubStr|Trim|Upper|GetAllClientScripts|MergeGlobalResources|PrepareForm|PrepareFormClientScript|ProcessXfdFormForImport|SyncDesignResources|SyncProgramaticResourcesAddProperty|ExecInternal|GetInternal|GetInternalC|HasProperty|SetInternal|SetInternalC|AddToApplication|AddToSession|ClearSession|FromJson|GetFromApplication|GetFromSession|ToJson|UrlDecode|UrlEncodeGetClientScriptReferences|GetFormReferences|MergeXfd|FromXml|HtmlDecode|HtmlEncode|ToXml|XmlDomToUdObject)\\w?\\(",
       "end": "(?<!\\.)",
       "patterns": [
         {
@@ -140,13 +143,51 @@
       ]
     },
     "navigatorVars": {
-      "name": "variable.other.constant",
+      "name": "starlims.navigator-variables",
       "match": "(?i)(MYUSERNAME|STARLIMSDEPT|MYUSERROLE)"
+    },
+    "iif": {
+      "name": "support.function",
+      "begin": "\\b(iif)(\\()",
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#expression"
+        },
+        {
+          "begin": ",",
+          "end": "(?=,)|(?=\\))",
+          "patterns": [
+            {
+              "include": "#expression"
+            }
+          ]
+        }
+      ]
+    },
+    "iif_in_sql": {
+      "name": "starlims.blue-function",
+      "begin": "\\b(iif)(\\()",
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#expression"
+        },
+        {
+          "begin": ",",
+          "end": "(?=,)|(?=\\))",
+          "patterns": [
+            {
+              "include": "#expression_in_sql"
+            }
+          ]
+        }
+      ]
     },
     "function": {
       "begin": "\\b[a-zA-Z_][a-zA-Z0-9_]*(\\()",
       "end": "\\)",
-      "name": "support.function",
+      "name": "entity.name.function",
       "patterns": [
         {
           "include": "#expression"
@@ -163,8 +204,8 @@
       ]
     },
     "langConstants": {
-      "name": "constant.character.escape",
-      "match": "(?i)\\.(t|T|f|F)\\."
+      "name": "constant.language",
+      "match": "\\.(t|T|f|F)\\."
     },
     "numbers": {
       "name": "constant.numeric",
@@ -184,12 +225,12 @@
       ]
     },
     "stringsDouble": {
-      "name": "meta.preprocessor.string",
+      "name": "string.quoted.double",
       "begin": "\"",
       "end": "\""
     },
     "stringsSingle": {
-      "name": "meta.preprocessor.string",
+      "name": "string.quoted.sinlge",
       "begin": "'",
       "end": "'"
     },
@@ -200,10 +241,10 @@
     "embeddedSqlString": {
       "begin": "(?i)(\")(select|insert|update|delete|create|drop|alter|truncate|grant|revoke|commit|rollback|set|declare|begin|call|execute|prepare|open|fetch|lock|unlock|merge|rename|replace|purge)\\s+",
       "end": "(\")",
-      "name": "source.sql",
+      "name": "source.slsql",
       "beginCaptures": {
         "0": {
-          "name": "keyword"
+          "name": "keyword.other.DML.sql"
         },
         "1": {
           "name": "string.quoted.double.sql"
@@ -219,7 +260,7 @@
           "include": "#variableInSQLString"
         },
         {
-          "include": "source.sql"
+          "include": "source.slsql"
         }
       ]
     }

--- a/themes/SSL Theme-color-theme.json
+++ b/themes/SSL Theme-color-theme.json
@@ -800,7 +800,8 @@
 				"keyword.other.cascade.sql",
 			],
 			"settings": {
-				"foreground": "#78b2e9"
+				"foreground": "#77baf8",
+				"fontStyle": "italic bold"
 			}
 		},
 		{

--- a/themes/SSL Theme-color-theme.json
+++ b/themes/SSL Theme-color-theme.json
@@ -1,0 +1,837 @@
+{
+	"name": "SSL Language Theme",
+	"type": "dark",
+	"$schema": "vscode://schemas/color-theme",
+	"colors": {
+		"activityBar.activeBorder": "#0078d4",
+		"activityBar.background": "#181818",
+		"activityBar.border": "#ffffff15",
+		"activityBar.foreground": "#d7d7d7",
+		"activityBar.inactiveForeground": "#ffffff80",
+		"activityBarBadge.background": "#0078d4",
+		"activityBarBadge.foreground": "#ffffff",
+		"badge.background": "#0078d4",
+		"badge.foreground": "#ffffff",
+		"button.background": "#0078d4",
+		"button.border": "#ffffff12",
+		"button.foreground": "#ffffff",
+		"button.hoverBackground": "#0078d4e6",
+		"button.secondaryBackground": "#ffffff0f",
+		"button.secondaryForeground": "#cccccc",
+		"button.secondaryHoverBackground": "#ffffff15",
+		"checkbox.background": "#313131",
+		"checkbox.border": "#ffffff1f",
+		"debugToolBar.background": "#181818",
+		"descriptionForeground": "#8b949e",
+		"diffEditor.insertedLineBackground": "#23863633",
+		"diffEditor.insertedTextBackground": "#2386364d",
+		"diffEditor.removedLineBackground": "#da363333",
+		"diffEditor.removedTextBackground": "#da36334d",
+		"dropdown.background": "#313131",
+		"dropdown.border": "#ffffff1f",
+		"dropdown.foreground": "#cccccc",
+		"dropdown.listBackground": "#313131",
+		"editor.background": "#1f1f1f",
+		"editor.findMatchBackground": "#9e6a03",
+		"editor.foreground": "#cccccc",
+		"editor.inactiveSelectionBackground": "#3a3d41",
+		"editor.selectionHighlightBackground": "#add6ff26",
+		"editorGroup.border": "#ffffff17",
+		"editorGroupHeader.tabsBackground": "#181818",
+		"editorGroupHeader.tabsBorder": "#ffffff15",
+		"editorGutter.addedBackground": "#2ea043",
+		"editorGutter.deletedBackground": "#f85149",
+		"editorGutter.modifiedBackground": "#0078d4",
+		"editorIndentGuide.activeBackground": "#707070",
+		"editorIndentGuide.background": "#404040",
+		"editorInlayHint.background": "#8b949e33",
+		"editorInlayHint.foreground": "#8b949e",
+		"editorInlayHint.typeBackground": "#8b949e33",
+		"editorInlayHint.typeForeground": "#8b949e",
+		"editorLineNumber.activeForeground": "#cccccc",
+		"editorLineNumber.foreground": "#6e7681",
+		"editorOverviewRuler.border": "#010409",
+		"editorWidget.background": "#1f1f1f",
+		"errorForeground": "#f85149",
+		"focusBorder": "#0078d4",
+		"foreground": "#cccccc",
+		"icon.foreground": "#cccccc",
+		"input.background": "#2a2a2a",
+		"input.border": "#ffffff1f",
+		"input.foreground": "#cccccc",
+		"input.placeholderForeground": "#ffffff79",
+		"inputOption.activeBackground": "#2489db82",
+		"inputOption.activeBorder": "#2488db",
+		"keybindingLabel.foreground": "#cccccc",
+		"list.activeSelectionBackground": "#323232",
+		"list.activeSelectionForeground": "#ffffff",
+		"list.activeSelectionIconForeground": "#ffffff",
+		"list.dropBackground": "#383b3d",
+		"menu.background": "#1f1f1f",
+		"menu.border": "#454545",
+		"menu.foreground": "#cccccc",
+		"menu.separatorBackground": "#454545",
+		"notificationCenterHeader.background": "#1f1f1f",
+		"notificationCenterHeader.foreground": "#cccccc",
+		"notifications.background": "#1f1f1f",
+		"notifications.border": "#ffffff15",
+		"notifications.foreground": "#cccccc",
+		"panel.background": "#181818",
+		"panel.border": "#ffffff15",
+		"panelInput.border": "#ffffff15",
+		"panelTitle.activeBorder": "#0078d4",
+		"panelTitle.activeForeground": "#cccccc",
+		"panelTitle.inactiveForeground": "#8b949e",
+		"peekViewEditor.background": "#1f1f1f",
+		"peekViewEditor.matchHighlightBackground": "#bb800966",
+		"peekViewResult.background": "#1f1f1f",
+		"peekViewResult.matchHighlightBackground": "#bb800966",
+		"pickerGroup.border": "#ffffff15",
+		"pickerGroup.foreground": "#8b949e",
+		"ports.iconRunningProcessForeground": "#369432",
+		"progressBar.background": "#0078d4",
+		"quickInput.background": "#1f1f1f",
+		"quickInput.foreground": "#cccccc",
+		"scrollbar.shadow": "#484f5833",
+		"scrollbarSlider.activeBackground": "#6e768187",
+		"scrollbarSlider.background": "#6e768133",
+		"scrollbarSlider.hoverBackground": "#6e768145",
+		"settings.dropdownBackground": "#313131",
+		"settings.dropdownBorder": "#ffffff1f",
+		"settings.headerForeground": "#ffffff",
+		"settings.modifiedItemIndicator": "#bb800966",
+		"sideBar.background": "#181818",
+		"sideBar.border": "#ffffff15",
+		"sideBar.foreground": "#cccccc",
+		"sideBarSectionHeader.background": "#181818",
+		"sideBarSectionHeader.border": "#ffffff15",
+		"sideBarSectionHeader.foreground": "#cccccc",
+		"sideBarTitle.foreground": "#cccccc",
+		"statusBar.background": "#181818",
+		"statusBar.border": "#ffffff15",
+		"statusBar.debuggingBackground": "#0078d4",
+		"statusBar.debuggingForeground": "#ffffff",
+		"statusBar.foreground": "#cccccc",
+		"statusBar.noFolderBackground": "#1f1f1f",
+		"statusBarItem.focusBorder": "#0078d4",
+		"statusBarItem.prominentBackground": "#6e768166",
+		"statusBarItem.remoteBackground": "#0078d4",
+		"statusBarItem.remoteForeground": "#ffffff",
+		"tab.activeBackground": "#1f1f1f",
+		"tab.activeBorder": "#1f1f1f",
+		"tab.activeBorderTop": "#0078d4",
+		"tab.activeForeground": "#ffffff",
+		"tab.border": "#ffffff15",
+		"tab.hoverBackground": "#1f1f1f",
+		"tab.inactiveBackground": "#181818",
+		"tab.inactiveForeground": "#ffffff80",
+		"tab.lastPinnedBorder": "#cccccc33",
+		"tab.unfocusedActiveBorder": "#1f1f1f",
+		"tab.unfocusedActiveBorderTop": "#ffffff15",
+		"tab.unfocusedHoverBackground": "#6e76811a",
+		"terminal.foreground": "#cccccc",
+		"terminal.inactiveSelectionBackground": "#3a3d41",
+		"terminal.tab.activeBorder": "#0078d4",
+		"textBlockQuote.background": "#010409",
+		"textBlockQuote.border": "#ffffff14",
+		"textCodeBlock.background": "#6e768166",
+		"textLink.activeForeground": "#40a6ff",
+		"textLink.foreground": "#40a6ff",
+		"textSeparator.foreground": "#21262d",
+		"titleBar.activeBackground": "#181818",
+		"titleBar.activeForeground": "#cccccc",
+		"titleBar.border": "#ffffff15",
+		"titleBar.inactiveBackground": "#1f1f1f",
+		"titleBar.inactiveForeground": "#8b949e",
+		"welcomePage.progress.foreground": "#0078d4",
+		"welcomePage.tileBackground": "#ffffff0f",
+		"widget.border": "#ffffff15",
+	},
+	"tokenColors": [
+		{
+			"scope": [
+				"meta.embedded",
+				"source.groovy.embedded",
+				"string meta.image.inline.markdown"
+			],
+			"settings": {
+				"foreground": "#D4D4D4"
+			}
+		},
+		{
+			"scope": "emphasis",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "strong",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"scope": "header",
+			"settings": {
+				"foreground": "#000080"
+			}
+		},
+		{
+			"scope": "comment",
+			"settings": {
+				"foreground": "#6A9955"
+			}
+		},
+		{
+			"scope": "constant.language",
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": [
+				"constant.numeric",
+				"constant.numeric.sql",
+				"variable.other.enummember",
+				"keyword.operator.plus.exponent",
+				"keyword.operator.minus.exponent"
+			],
+			"settings": {
+				"foreground": "#B5CEA8"
+			}
+		},
+		{
+			"scope": "constant.regexp",
+			"settings": {
+				"foreground": "#646695"
+			}
+		},
+		{
+			"scope": "entity.name.tag",
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": "entity.name.tag.css",
+			"settings": {
+				"foreground": "#D7BA7D"
+			}
+		},
+		{
+			"scope": "entity.other.attribute-name",
+			"settings": {
+				"foreground": "#9CDCFE"
+			}
+		},
+		{
+			"scope": [
+				"entity.other.attribute-name.class.css",
+				"entity.other.attribute-name.class.mixin.css",
+				"entity.other.attribute-name.id.css",
+				"entity.other.attribute-name.parent-selector.css",
+				"entity.other.attribute-name.pseudo-class.css",
+				"entity.other.attribute-name.pseudo-element.css",
+				"source.css.less entity.other.attribute-name.id",
+				"entity.other.attribute-name.scss"
+			],
+			"settings": {
+				"foreground": "#D7BA7D"
+			}
+		},
+		{
+			"scope": "invalid",
+			"settings": {
+				"foreground": "#F44747"
+			}
+		},
+		{
+			"scope": "markup.underline",
+			"settings": {
+				"fontStyle": "underline"
+			}
+		},
+		{
+			"scope": "markup.bold",
+			"settings": {
+				"foreground": "#569CD6",
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"scope": "markup.heading",
+			"settings": {
+				"foreground": "#569CD6",
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"scope": "markup.italic",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "markup.strikethrough",
+			"settings": {
+				"fontStyle": "strikethrough"
+			}
+		},
+		{
+			"scope": "markup.inserted",
+			"settings": {
+				"foreground": "#B5CEA8"
+			}
+		},
+		{
+			"scope": "markup.deleted",
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"scope": "markup.changed",
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": "punctuation.definition.quote.begin.markdown",
+			"settings": {
+				"foreground": "#6A9955"
+			}
+		},
+		{
+			"scope": "punctuation.definition.list.begin.markdown",
+			"settings": {
+				"foreground": "#6796E6"
+			}
+		},
+		{
+			"scope": "markup.inline.raw",
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"scope": "punctuation.definition.tag",
+			"settings": {
+				"foreground": "#808080"
+			}
+		},
+		{
+			"scope": [
+				"meta.preprocessor",
+				"entity.name.function.preprocessor"
+			],
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": "meta.preprocessor.string",
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"scope": "meta.preprocessor.numeric",
+			"settings": {
+				"foreground": "#B5CEA8"
+			}
+		},
+		{
+			"scope": "meta.structure.dictionary.key.python",
+			"settings": {
+				"foreground": "#9CDCFE"
+			}
+		},
+		{
+			"scope": "meta.diff.header",
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": "storage",
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": "storage.type",
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": [
+				"storage.modifier",
+				"keyword.operator.noexcept"
+			],
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": [
+				"string",
+				"meta.embedded.assembly",
+				"punctuation.definition.string.begin.sql",
+				"punctuation.definition.string.end.sql"
+			],
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"scope": "string.tag",
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"scope": "string.value",
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"scope": "string.regexp",
+			"settings": {
+				"foreground": "#D16969"
+			}
+		},
+		{
+			"scope": [
+				"punctuation.definition.template-expression.begin",
+				"punctuation.definition.template-expression.end",
+				"punctuation.section.embedded"
+			],
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": [
+				"meta.template.expression"
+			],
+			"settings": {
+				"foreground": "#D4D4D4"
+			}
+		},
+		{
+			"scope": [
+				"support.type.vendored.property-name",
+				"support.type.property-name",
+				"variable.css",
+				"variable.scss",
+				"variable.other.less",
+				"source.coffee.embedded"
+			],
+			"settings": {
+				"foreground": "#9CDCFE"
+			}
+		},
+		{
+			"scope": "keyword",
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": "keyword.control",
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": "keyword.operator",
+			"settings": {
+				"foreground": "#D4D4D4"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.new",
+				"keyword.operator.expression",
+				"keyword.operator.cast",
+				"keyword.operator.sizeof",
+				"keyword.operator.alignof",
+				"keyword.operator.typeid",
+				"keyword.operator.alignas",
+				"keyword.operator.instanceof",
+				"keyword.operator.logical.python",
+				"keyword.operator.wordlike"
+			],
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": "keyword.other.unit",
+			"settings": {
+				"foreground": "#B5CEA8"
+			}
+		},
+		{
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": "support.function.git-rebase",
+			"settings": {
+				"foreground": "#9CDCFE"
+			}
+		},
+		{
+			"scope": "constant.sha.git-rebase",
+			"settings": {
+				"foreground": "#B5CEA8"
+			}
+		},
+		{
+			"scope": [
+				"storage.modifier.import.java",
+				"variable.language.wildcard.java",
+				"storage.modifier.package.java"
+			],
+			"settings": {
+				"foreground": "#D4D4D4"
+			}
+		},
+		{
+			"scope": "variable.language",
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.function",
+				"support.function",
+				"support.constant.handlebars",
+				"source.powershell variable.other.member",
+				"entity.name.operator.custom-literal"
+			],
+			"settings": {
+				"foreground": "#DCDCAA"
+			}
+		},
+		{
+			"scope": [
+				"support.class",
+				"support.type",
+				"entity.name.type",
+				"entity.name.namespace",
+				"entity.other.attribute",
+				"entity.name.scope-resolution",
+				"entity.name.class",
+				"storage.type.numeric.go",
+				"storage.type.byte.go",
+				"storage.type.boolean.go",
+				"storage.type.string.go",
+				"storage.type.uintptr.go",
+				"storage.type.error.go",
+				"storage.type.rune.go",
+				"storage.type.cs",
+				"storage.type.generic.cs",
+				"storage.type.modifier.cs",
+				"storage.type.variable.cs",
+				"storage.type.annotation.java",
+				"storage.type.generic.java",
+				"storage.type.java",
+				"storage.type.object.array.java",
+				"storage.type.primitive.array.java",
+				"storage.type.primitive.java",
+				"storage.type.token.java",
+				"storage.type.groovy",
+				"storage.type.annotation.groovy",
+				"storage.type.parameters.groovy",
+				"storage.type.generic.groovy",
+				"storage.type.object.array.groovy",
+				"storage.type.primitive.array.groovy",
+				"storage.type.primitive.groovy"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"scope": [
+				"meta.type.cast.expr",
+				"meta.type.new.expr",
+				"support.constant.math",
+				"support.constant.dom",
+				"support.constant.json",
+				"entity.other.inherited-class"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"scope": [
+				"keyword.control",
+				"source.cpp keyword.operator.new",
+				"keyword.operator.delete",
+				"keyword.other.using",
+				"keyword.other.operator",
+				"entity.name.operator"
+			],
+			"settings": {
+				"foreground": "#C586C0"
+			}
+		},
+		{
+			"scope": [
+				"variable",
+				"meta.definition.variable.name",
+				"support.variable",
+				"entity.name.variable",
+				"constant.other.placeholder"
+			],
+			"settings": {
+				"foreground": "#9CDCFE"
+			}
+		},
+		{
+			"scope": [
+				"variable.other.constant",
+				"variable.other.enummember"
+			],
+			"settings": {
+				"foreground": "#4FC1FF"
+			}
+		},
+		{
+			"scope": [
+				"meta.object-literal.key"
+			],
+			"settings": {
+				"foreground": "#9CDCFE"
+			}
+		},
+		{
+			"scope": [
+				"support.constant.property-value",
+				"support.constant.font-name",
+				"support.constant.media-type",
+				"support.constant.media",
+				"constant.other.color.rgb-value",
+				"constant.other.rgb-value",
+				"support.constant.color"
+			],
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"scope": [
+				"punctuation.definition.group.regexp",
+				"punctuation.definition.group.assertion.regexp",
+				"punctuation.definition.character-class.regexp",
+				"punctuation.character.set.begin.regexp",
+				"punctuation.character.set.end.regexp",
+				"keyword.operator.negation.regexp",
+				"support.other.parenthesis.regexp"
+			],
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"scope": [
+				"constant.character.character-class.regexp",
+				"constant.other.character-class.set.regexp",
+				"constant.other.character-class.regexp",
+				"constant.character.set.regexp",
+				"constant.character.escape.slash.sql"
+			],
+			"settings": {
+				"foreground": "#D16969"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.or.regexp",
+				"keyword.control.anchor.regexp"
+			],
+			"settings": {
+				"foreground": "#DCDCAA"
+			}
+		},
+		{
+			"scope": "keyword.operator.quantifier.regexp",
+			"settings": {
+				"foreground": "#D7BA7D"
+			}
+		},
+		{
+			"scope": [
+				"constant.character",
+				"constant.other.option"
+			],
+			"settings": {
+				"foreground": "#569CD6"
+			}
+		},
+		{
+			"scope": "constant.character.escape",
+			"settings": {
+				"foreground": "#D7BA7D"
+			}
+		},
+		{
+			"scope": "entity.name.label",
+			"settings": {
+				"foreground": "#C8C8C8"
+			}
+		},
+		{
+			"scope": "token.info-token",
+			"settings": {
+				"foreground": "#6796E6"
+			}
+		},
+		{
+			"scope": "token.warn-token",
+			"settings": {
+				"foreground": "#CD9731"
+			}
+		},
+		{
+			"scope": "token.error-token",
+			"settings": {
+				"foreground": "#F44747"
+			}
+		},
+		{
+			"scope": "token.debug-token",
+			"settings": {
+				"foreground": "#B267E6"
+			}
+		},
+		{
+			"name": "STARLIMS SSL Keyword Control",
+			"scope": [
+				"starlims.ssl.keyword.control",
+				"starlims.ssl.keyword.storage"
+			],
+			"settings": {
+				"foreground": "#ff6169"
+			}
+		},
+		{
+			"name": "STARLIMS SSL Blue Function",
+			"scope": [
+				"starlims.blue-function"
+			],
+			"settings": {
+				"foreground": "#4f87ff"
+			}
+		},
+		{
+			"name": "STARLIMS Navigator Variables",
+			"scope": [
+				"starlims.navigator-variables"
+			],
+			"settings": {
+				"foreground": "#d5ffb9"
+			}
+		},
+		{
+			"name": "SLSQL Table and Database Names",
+			"scope": [
+				"keyword.table.sql",
+				"text.bracketed",
+				"constant.other.database-name.sql"
+			],
+			"settings": {
+				"foreground": "#68c597"
+			}
+		},
+		{
+			"name": "SLSQL Field Names",
+			"scope": [
+				"constant.other.field-name.sql"
+			],
+			"settings": {
+				"foreground": "#dfdfdf"
+			}
+		},		
+		{
+			"name": "SLSQL Table and Database Names",
+			"scope": [
+				"text.bracketed",
+				"constant.other.database-name.sql",
+				"keyword.other.table.sql"
+			],
+			"settings": {
+				"foreground": "#68c597"
+			}
+		},
+		{
+			"name": "SLSQL Data Types",
+			"scope": [
+				"storage.type.sql",
+			],
+			"settings": {
+				"foreground": "#ffb2f9"
+			}
+		},
+		{
+			"name": "SLSQL Keyword Control",
+			"scope": [
+				"keyword.other.create.sql",
+				"keyword.other.DML.sql",
+				"keyword.other.DDL.create.II.sql",
+				"keyword.other.LUW.sql",
+				"keyword.other.sql",
+				"storage.modifier.sql",
+				"meta.drop.sql",
+				"meta.create.sql",
+				"entity.name.function.sql",
+				"keyword.other.cascade.sql",
+			],
+			"settings": {
+				"foreground": "#78b2e9"
+			}
+		},
+		{
+			"name": "SLSQL Operators",
+			"scope": [
+				"comparison.operator.sql",
+				"keyword.operator.math.sql",
+				"keyword.operator.star.sql",
+				"constant.character.escape.sql"
+			],
+			"settings": {
+				"foreground": "#d5ffe0"
+			}
+		},
+		{
+			"name": "SLSQL Parameter",
+			"scope": [
+				"variable.parameter.sql",
+			],
+			"settings": {
+				"foreground": "#c5b768"
+			}
+		},
+		{
+			"name": "SLSQL Functions",
+			"scope": [
+				"keyword.function.sql",
+			],
+			"settings": {
+				"foreground": "#d987ff"
+			}
+		}
+	]
+}


### PR DESCRIPTION
* Added .slsql support for datasources in SQL
* Fixed comment blocks for SSL datasources
* Fixed SQL highlighting in strings
* Added navigator variables highlighting
* Removed separate "IIf" and added it to blue functions

I guess we can shorten the sql.tmLanguage.json file and just use source.sql. I'm working on it...